### PR TITLE
Add MVP LMDB storage adapter

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,12 @@
     .version = "0.0.0",
     .fingerprint = 0x17dffd899bdb5740,
     .minimum_zig_version = "0.15.1",
-    .dependencies = .{},
+    .dependencies = .{
+        .lmdb = .{
+            .url = "https://github.com/LMDB/lmdb/archive/refs/tags/LMDB_0.9.31.tar.gz",
+            .hash = "N-V-__8AAHEsCACb_b9D1HnCysDKIhKFOrITbxYh9JRh9ix5",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -16,3 +16,4 @@ pub const crypto = struct {
 };
 
 pub const record = @import("record.zig");
+pub const storage = @import("storage.zig");

--- a/src/lmdb.zig
+++ b/src/lmdb.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+const c = @cImport({
+    @cInclude("lmdb.h");
+});
+
+const Allocator = std.mem.Allocator;
+const heap = std.heap;
+
+pub const Error = error{
+    INVAL,
+    ACCES,
+    NOMEM,
+    NOENT,
+    AGAIN,
+    NOSPC,
+    BUSY,
+    INTR,
+    PIPE,
+    IO,
+
+    MDB_KEYEXIST,
+    MDB_NOTFOUND,
+    MDB_PAGE_NOTFOUND,
+    MDB_CORRUPTED,
+    MDB_PANIC,
+    MDB_VERSION_MISMATCH,
+    MDB_INVALID,
+    MDB_MAP_FULL,
+    MDB_DBS_FULL,
+    MDB_READERS_FULL,
+    MDB_TLS_FULL,
+    MDB_TXN_FULL,
+    MDB_CURSOR_FULL,
+    MDB_PAGE_FULL,
+    MDB_MAP_RESIZED,
+    MDB_INCOMPATIBLE,
+    MDB_BAD_RSLOT,
+    MDB_BAD_TXN,
+    MDB_BAD_VALSIZE,
+    MDB_BAD_DBI,
+
+    MDB_UNKNOWN_ERROR,
+};
+
+fn throw(rc: c_int) Error!void {
+    try switch (rc) {
+        c.MDB_SUCCESS => {},
+        c.MDB_KEYEXIST => Error.MDB_KEYEXIST,
+        c.MDB_NOTFOUND => Error.MDB_NOTFOUND,
+        c.MDB_PAGE_NOTFOUND => Error.MDB_PAGE_NOTFOUND,
+        c.MDB_CORRUPTED => Error.MDB_CORRUPTED,
+        c.MDB_PANIC => Error.MDB_PANIC,
+        c.MDB_VERSION_MISMATCH => Error.MDB_VERSION_MISMATCH,
+        c.MDB_INVALID => Error.MDB_INVALID,
+        c.MDB_MAP_FULL => Error.MDB_MAP_FULL,
+        c.MDB_DBS_FULL => Error.MDB_DBS_FULL,
+        c.MDB_READERS_FULL => Error.MDB_READERS_FULL,
+        c.MDB_TLS_FULL => Error.MDB_TLS_FULL,
+        c.MDB_TXN_FULL => Error.MDB_TXN_FULL,
+        c.MDB_CURSOR_FULL => Error.MDB_CURSOR_FULL,
+        c.MDB_PAGE_FULL => Error.MDB_PAGE_FULL,
+        c.MDB_MAP_RESIZED => Error.MDB_MAP_RESIZED,
+        c.MDB_INCOMPATIBLE => Error.MDB_INCOMPATIBLE,
+        c.MDB_BAD_RSLOT => Error.MDB_BAD_RSLOT,
+        c.MDB_BAD_TXN => Error.MDB_BAD_TXN,
+        c.MDB_BAD_VALSIZE => Error.MDB_BAD_VALSIZE,
+        c.MDB_BAD_DBI => Error.MDB_BAD_DBI,
+        @intFromEnum(std.posix.E.INVAL) => Error.INVAL,
+        @intFromEnum(std.posix.E.ACCES) => Error.ACCES,
+        @intFromEnum(std.posix.E.NOMEM) => Error.NOMEM,
+        @intFromEnum(std.posix.E.NOENT) => Error.NOENT,
+        @intFromEnum(std.posix.E.AGAIN) => Error.AGAIN,
+        @intFromEnum(std.posix.E.NOSPC) => Error.NOSPC,
+        @intFromEnum(std.posix.E.BUSY) => Error.BUSY,
+        @intFromEnum(std.posix.E.INTR) => Error.INTR,
+        @intFromEnum(std.posix.E.PIPE) => Error.PIPE,
+        @intFromEnum(std.posix.E.IO) => Error.IO,
+        else => Error.MDB_UNKNOWN_ERROR,
+    };
+}
+
+inline fn sliceToVal(slice: []const u8) c.MDB_val {
+    const ptr = @constCast(slice.ptr);
+    const any_ptr: ?*anyopaque = @ptrCast(ptr);
+    return .{
+        .mv_size = slice.len,
+        .mv_data = any_ptr,
+    };
+}
+
+inline fn valToSlice(val: c.MDB_val) []const u8 {
+    if (val.mv_data == null) return &[_]u8{};
+    const raw_ptr = val.mv_data.?;
+    const bytes_ptr: [*]u8 = @ptrCast(raw_ptr);
+    return bytes_ptr[0..val.mv_size];
+}
+
+pub const Environment = struct {
+    const Env = @This();
+
+    ptr: *c.MDB_env,
+
+    pub const Options = struct {
+        map_size: usize = 0,
+        max_dbs: u32 = 0,
+        max_readers: u32 = 0,
+        read_only: bool = false,
+        write_map: bool = false,
+        no_tls: bool = false,
+        no_lock: bool = false,
+        no_sync: bool = false,
+        no_meta_sync: bool = false,
+        map_async: bool = false,
+        mode: c.mdb_mode_t = 0o664,
+    };
+
+    pub fn init(path: [:0]const u8, options: Options) !Environment {
+        var env_ptr: ?*c.MDB_env = null;
+        try throw(c.mdb_env_create(&env_ptr));
+        errdefer c.mdb_env_close(env_ptr);
+
+        if (options.map_size != 0) {
+            try throw(c.mdb_env_set_mapsize(env_ptr, options.map_size));
+        }
+        if (options.max_dbs != 0) {
+            try throw(c.mdb_env_set_maxdbs(env_ptr, options.max_dbs));
+        }
+        if (options.max_readers != 0) {
+            try throw(c.mdb_env_set_maxreaders(env_ptr, options.max_readers));
+        }
+
+        var flags: c_uint = 0;
+        if (options.read_only) flags |= c.MDB_RDONLY;
+        if (options.write_map) flags |= c.MDB_WRITEMAP;
+        if (options.no_tls) flags |= c.MDB_NOTLS;
+        if (options.no_lock) flags |= c.MDB_NOLOCK;
+        if (options.no_sync) flags |= c.MDB_NOSYNC;
+        if (options.no_meta_sync) flags |= c.MDB_NOMETASYNC;
+        if (options.map_async) flags |= c.MDB_MAPASYNC;
+
+        try throw(c.mdb_env_open(env_ptr, path, flags, options.mode));
+        return .{ .ptr = env_ptr.? };
+    }
+
+    pub fn deinit(self: Environment) void {
+        c.mdb_env_close(self.ptr);
+    }
+
+    pub const Transaction = struct {
+        const Self = @This();
+
+        ptr: *c.MDB_txn,
+
+        pub const Mode = enum { ReadOnly, ReadWrite };
+
+        pub const Options = struct {
+            mode: Mode = .ReadWrite,
+            parent: ?*c.MDB_txn = null,
+        };
+
+        pub fn abort(self: Self) void {
+            c.mdb_txn_abort(self.ptr);
+        }
+
+        pub fn commit(self: Self) !void {
+            try throw(c.mdb_txn_commit(self.ptr));
+        }
+
+        pub fn database(self: Self, name: []const u8, options: Database.Options) !Database {
+            var dbi: c.MDB_dbi = undefined;
+            var flags: c_uint = 0;
+            if (options.reverse_key) flags |= c.MDB_REVERSEKEY;
+            if (options.integer_key) flags |= c.MDB_INTEGERKEY;
+            if (options.create) flags |= c.MDB_CREATE;
+
+            if (name.len == 0) {
+                try throw(c.mdb_dbi_open(self.ptr, null, flags, &dbi));
+            } else if (name.len <= 128) {
+                var buf: [129]u8 = undefined;
+                std.mem.copyForwards(u8, buf[0..name.len], name);
+                buf[name.len] = 0;
+                const name_ptr: [*:0]const u8 = @ptrCast(buf[0 .. name.len + 1].ptr);
+                try throw(c.mdb_dbi_open(self.ptr, name_ptr, flags, &dbi));
+            } else {
+                const tmp = try heap.page_allocator.allocSentinel(u8, name.len, 0);
+                defer heap.page_allocator.free(tmp);
+                std.mem.copyForwards(u8, tmp[0..name.len], name);
+                const name_ptr: [*:0]const u8 = @ptrCast(tmp.ptr);
+                try throw(c.mdb_dbi_open(self.ptr, name_ptr, flags, &dbi));
+            }
+
+            return .{ .txn_ptr = self.ptr, .dbi = dbi };
+        }
+    };
+
+    pub fn transaction(self: Env, options: Env.Transaction.Options) !Env.Transaction {
+        var txn_ptr: ?*c.MDB_txn = null;
+        var flags: c_uint = 0;
+        switch (options.mode) {
+            .ReadOnly => flags |= c.MDB_RDONLY,
+            .ReadWrite => {},
+        }
+        try throw(c.mdb_txn_begin(self.ptr, options.parent, flags, &txn_ptr));
+        return .{ .ptr = txn_ptr.? };
+    }
+};
+
+pub const Database = struct {
+    const Self = @This();
+
+    txn_ptr: *c.MDB_txn,
+    dbi: c.MDB_dbi,
+
+    pub const Options = struct {
+        reverse_key: bool = false,
+        integer_key: bool = false,
+        create: bool = false,
+    };
+
+    pub fn set(self: Self, key: []const u8, value: []const u8) !void {
+        var k = sliceToVal(key);
+        var v = sliceToVal(value);
+        try throw(c.mdb_put(self.txn_ptr, self.dbi, &k, &v, 0));
+    }
+
+    pub fn get(self: Self, key: []const u8) !?[]const u8 {
+        var k = sliceToVal(key);
+        var v: c.MDB_val = .{ .mv_size = 0, .mv_data = null };
+        const rc = c.mdb_get(self.txn_ptr, self.dbi, &k, &v);
+        if (rc == c.MDB_NOTFOUND) return null;
+        try throw(rc);
+        return valToSlice(v);
+    }
+
+    pub fn delete(self: Self, key: []const u8) !void {
+        var k = sliceToVal(key);
+        try throw(c.mdb_del(self.txn_ptr, self.dbi, &k, null));
+    }
+
+    pub fn cursor(self: Self) !Cursor {
+        var cursor_ptr: ?*c.MDB_cursor = null;
+        try throw(c.mdb_cursor_open(self.txn_ptr, self.dbi, &cursor_ptr));
+        return .{ .ptr = cursor_ptr.? };
+    }
+};
+
+pub const Cursor = struct {
+    const Self = @This();
+
+    ptr: *c.MDB_cursor,
+
+    pub fn deinit(self: Self) void {
+        c.mdb_cursor_close(self.ptr);
+    }
+
+    pub fn getCurrentValue(self: Self) ![]const u8 {
+        var v: c.MDB_val = undefined;
+        try throw(c.mdb_cursor_get(self.ptr, null, &v, c.MDB_GET_CURRENT));
+        return valToSlice(v);
+    }
+
+    pub fn goToNext(self: Self) !?[]const u8 {
+        var k: c.MDB_val = undefined;
+        const rc = c.mdb_cursor_get(self.ptr, &k, null, c.MDB_NEXT);
+        if (rc == c.MDB_NOTFOUND) return null;
+        try throw(rc);
+        return valToSlice(k);
+    }
+
+    pub fn seek(self: Self, key: []const u8) !?[]const u8 {
+        var k = sliceToVal(key);
+        const rc = c.mdb_cursor_get(self.ptr, &k, null, c.MDB_SET_RANGE);
+        if (rc == c.MDB_NOTFOUND) return null;
+        try throw(rc);
+        return valToSlice(k);
+    }
+};
+
+pub const Transaction = Environment.Transaction;

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -1,0 +1,470 @@
+const std = @import("std");
+const lmdb = @import("lmdb");
+const record_mod = @import("record.zig");
+
+const Record = record_mod.Record;
+const RecordError = record_mod.RecordError;
+
+const ID_LEN = 48;
+const ADDRESS_OFFSET = 48;
+const ADDRESS_LEN = 48;
+const TIMESTAMP_BYTES = 8;
+const KIND_BYTES = 8;
+
+const DB_RECORDS = "records";
+const DB_ADDRESS = "idx_address";
+const DB_KIND = "idx_kind";
+const DB_TIMESTAMP = "idx_timestamp";
+
+pub const Error = RecordError || lmdb.Error || std.mem.Allocator.Error || std.fs.Dir.MakeError || std.fs.Dir.StatFileError || error{
+    InvalidKeyLength,
+    DataCorruption,
+};
+
+pub const Storage = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    env: lmdb.Environment,
+
+    pub const Options = struct {
+        path: []const u8,
+        map_size: usize = 64 * 1024 * 1024,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, options: Options) Error!Self {
+        try std.fs.cwd().makePath(options.path);
+        var path_z = try allocator.allocSentinel(u8, options.path.len, 0);
+        defer allocator.free(path_z);
+        std.mem.copyForwards(u8, path_z[0..options.path.len], options.path);
+
+        var env = try lmdb.Environment.init(path_z, .{
+            .map_size = options.map_size,
+            .max_dbs = 8,
+            .max_readers = 128,
+        });
+        errdefer env.deinit();
+
+        var storage = Self{
+            .allocator = allocator,
+            .env = env,
+        };
+
+        try storage.ensureDbs();
+        return storage;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.env.deinit();
+        self.* = undefined;
+    }
+
+    pub fn put(self: *Self, record_bytes: []const u8) Error!void {
+        const rec = try Record.fromBytes(record_bytes);
+        var txn = try self.env.transaction(.{ .mode = .ReadWrite });
+        errdefer txn.abort();
+
+        var records_db = try txn.database(DB_RECORDS, .{ .create = true });
+        var address_db = try txn.database(DB_ADDRESS, .{ .create = true });
+        var kind_db = try txn.database(DB_KIND, .{ .create = true });
+        var timestamp_db = try txn.database(DB_TIMESTAMP, .{ .create = true });
+
+        const id_slice = rec.bytes[0..ID_LEN];
+
+        if (try records_db.get(id_slice)) |existing_bytes| {
+            const owned = try self.allocator.dupe(u8, existing_bytes);
+            defer self.allocator.free(owned);
+            const existing_rec = try Record.fromBytes(owned);
+            try self.deindexRecord(&txn, existing_rec, &address_db, &kind_db, &timestamp_db);
+        }
+
+        try records_db.set(id_slice, record_bytes);
+        try self.indexRecord(&txn, rec, &address_db, &kind_db, &timestamp_db);
+
+        try txn.commit();
+    }
+
+    pub fn getById(self: *Self, allocator: std.mem.Allocator, id: []const u8) Error!?[]u8 {
+        if (id.len != ID_LEN) return error.InvalidKeyLength;
+        var txn = try self.env.transaction(.{ .mode = .ReadOnly });
+        defer txn.abort();
+
+        const records_db = try txn.database(DB_RECORDS, .{});
+        if (try records_db.get(id)) |value| {
+            return try allocator.dupe(u8, value);
+        }
+        return null;
+    }
+
+    pub fn delete(self: *Self, id: []const u8) Error!bool {
+        if (id.len != ID_LEN) return error.InvalidKeyLength;
+        var txn = try self.env.transaction(.{ .mode = .ReadWrite });
+        errdefer txn.abort();
+
+        var records_db = try txn.database(DB_RECORDS, .{});
+        var address_db = try txn.database(DB_ADDRESS, .{});
+        var kind_db = try txn.database(DB_KIND, .{});
+        var timestamp_db = try txn.database(DB_TIMESTAMP, .{});
+
+        const existing = try records_db.get(id) orelse return false;
+        const owned = try self.allocator.dupe(u8, existing);
+        defer self.allocator.free(owned);
+        const existing_rec = try Record.fromBytes(owned);
+
+        try self.deindexRecord(&txn, existing_rec, &address_db, &kind_db, &timestamp_db);
+        try records_db.delete(id);
+        try txn.commit();
+        return true;
+    }
+
+    pub fn getByAddress(
+        self: *Self,
+        allocator: std.mem.Allocator,
+        address: []const u8,
+        limit: usize,
+    ) Error!RecordList {
+        if (address.len != ADDRESS_LEN) return error.InvalidKeyLength;
+        if (limit == 0) return RecordList.empty(allocator);
+
+        var txn = try self.env.transaction(.{ .mode = .ReadOnly });
+        defer txn.abort();
+
+        const address_db = try txn.database(DB_ADDRESS, .{});
+        const records_db = try txn.database(DB_RECORDS, .{});
+
+        var cursor = try address_db.cursor();
+        defer cursor.deinit();
+
+        var results = RecordListBuilder.init(allocator);
+        errdefer results.deinit();
+
+        var search_key: [ADDRESS_LEN + TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.copyForwards(u8, search_key[0..ADDRESS_LEN], address);
+        @memset(search_key[ADDRESS_LEN .. ADDRESS_LEN + TIMESTAMP_BYTES], 0);
+        @memset(search_key[ADDRESS_LEN + TIMESTAMP_BYTES ..], 0);
+
+        var current = try cursor.seek(search_key[0..]);
+        while (current) |key| {
+            if (!std.mem.eql(u8, key[0..ADDRESS_LEN], address)) break;
+            const record_id = try cursor.getCurrentValue();
+            const owned_record = try copyRecord(allocator, records_db, record_id);
+            try results.append(owned_record);
+            if (results.len() >= limit) break;
+            current = try cursor.goToNext();
+        }
+
+        return results.toList();
+    }
+
+    pub fn getByKind(
+        self: *Self,
+        allocator: std.mem.Allocator,
+        kind: u64,
+        since: u64,
+        until: u64,
+        limit: usize,
+    ) Error!RecordList {
+        if (limit == 0 or since > until) return RecordList.empty(allocator);
+
+        var txn = try self.env.transaction(.{ .mode = .ReadOnly });
+        defer txn.abort();
+
+        const kind_db = try txn.database(DB_KIND, .{});
+        const records_db = try txn.database(DB_RECORDS, .{});
+
+        var cursor = try kind_db.cursor();
+        defer cursor.deinit();
+
+        var results = RecordListBuilder.init(allocator);
+        errdefer results.deinit();
+
+        var search_key: [KIND_BYTES + TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.writeInt(u64, search_key[0..KIND_BYTES], kind, .big);
+        std.mem.writeInt(u64, search_key[KIND_BYTES .. KIND_BYTES + TIMESTAMP_BYTES], since, .big);
+        @memset(search_key[KIND_BYTES + TIMESTAMP_BYTES ..], 0);
+
+        var current = try cursor.seek(search_key[0..]);
+        while (current) |key| {
+            if (!std.mem.eql(u8, key[0..KIND_BYTES], search_key[0..KIND_BYTES])) break;
+            const ts = std.mem.readInt(u64, key[KIND_BYTES .. KIND_BYTES + TIMESTAMP_BYTES], .big);
+            if (ts > until) break;
+            const record_id = try cursor.getCurrentValue();
+            const owned_record = try copyRecord(allocator, records_db, record_id);
+            try results.append(owned_record);
+            if (results.len() >= limit) break;
+            current = try cursor.goToNext();
+        }
+
+        return results.toList();
+    }
+
+    pub fn getByTimestamp(
+        self: *Self,
+        allocator: std.mem.Allocator,
+        since: u64,
+        until: u64,
+        limit: usize,
+    ) Error!RecordList {
+        if (limit == 0 or since > until) return RecordList.empty(allocator);
+
+        var txn = try self.env.transaction(.{ .mode = .ReadOnly });
+        defer txn.abort();
+
+        const timestamp_db = try txn.database(DB_TIMESTAMP, .{});
+        const records_db = try txn.database(DB_RECORDS, .{});
+
+        var cursor = try timestamp_db.cursor();
+        defer cursor.deinit();
+
+        var results = RecordListBuilder.init(allocator);
+        errdefer results.deinit();
+
+        var search_key: [TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.writeInt(u64, search_key[0..TIMESTAMP_BYTES], since, .big);
+        @memset(search_key[TIMESTAMP_BYTES..], 0);
+
+        var current = try cursor.seek(search_key[0..]);
+        while (current) |key| {
+            const ts = std.mem.readInt(u64, key[0..TIMESTAMP_BYTES], .big);
+            if (ts > until) break;
+            const record_id = try cursor.getCurrentValue();
+            const owned_record = try copyRecord(allocator, records_db, record_id);
+            try results.append(owned_record);
+            if (results.len() >= limit) break;
+            current = try cursor.goToNext();
+        }
+
+        return results.toList();
+    }
+
+    fn ensureDbs(self: *Self) Error!void {
+        var txn = try self.env.transaction(.{ .mode = .ReadWrite });
+        errdefer txn.abort();
+        _ = try txn.database(DB_RECORDS, .{ .create = true });
+        _ = try txn.database(DB_ADDRESS, .{ .create = true });
+        _ = try txn.database(DB_KIND, .{ .create = true });
+        _ = try txn.database(DB_TIMESTAMP, .{ .create = true });
+        try txn.commit();
+    }
+
+    fn indexRecord(
+        self: *Self,
+        txn: *lmdb.Transaction,
+        rec: Record,
+        address_db: *lmdb.Database,
+        kind_db: *lmdb.Database,
+        timestamp_db: *lmdb.Database,
+    ) Error!void {
+        _ = self;
+        _ = txn;
+        const id_slice = rec.bytes[0..ID_LEN];
+        const timestamp = rec.timestamp();
+
+        var ts_key: [TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.writeInt(u64, ts_key[0..TIMESTAMP_BYTES], timestamp, .big);
+        std.mem.copyForwards(u8, ts_key[TIMESTAMP_BYTES..], id_slice);
+        try timestamp_db.set(ts_key[0..], id_slice);
+
+        var address_key: [ADDRESS_LEN + TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.copyForwards(u8, address_key[0..ADDRESS_LEN], rec.bytes[ADDRESS_OFFSET .. ADDRESS_OFFSET + ADDRESS_LEN]);
+        std.mem.writeInt(u64, address_key[ADDRESS_LEN .. ADDRESS_LEN + TIMESTAMP_BYTES], timestamp, .big);
+        std.mem.copyForwards(u8, address_key[ADDRESS_LEN + TIMESTAMP_BYTES ..], id_slice);
+        try address_db.set(address_key[0..], id_slice);
+
+        var kind_key: [KIND_BYTES + TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.writeInt(u64, kind_key[0..KIND_BYTES], rec.kind(), .big);
+        std.mem.writeInt(u64, kind_key[KIND_BYTES .. KIND_BYTES + TIMESTAMP_BYTES], timestamp, .big);
+        std.mem.copyForwards(u8, kind_key[KIND_BYTES + TIMESTAMP_BYTES ..], id_slice);
+        try kind_db.set(kind_key[0..], id_slice);
+    }
+
+    fn deindexRecord(
+        self: *Self,
+        txn: *lmdb.Transaction,
+        rec: Record,
+        address_db: *lmdb.Database,
+        kind_db: *lmdb.Database,
+        timestamp_db: *lmdb.Database,
+    ) Error!void {
+        _ = self;
+        _ = txn;
+        const id_slice = rec.bytes[0..ID_LEN];
+        const timestamp = rec.timestamp();
+
+        var ts_key: [TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.writeInt(u64, ts_key[0..TIMESTAMP_BYTES], timestamp, .big);
+        std.mem.copyForwards(u8, ts_key[TIMESTAMP_BYTES..], id_slice);
+        try timestamp_db.delete(ts_key[0..]);
+
+        var address_key: [ADDRESS_LEN + TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.copyForwards(u8, address_key[0..ADDRESS_LEN], rec.bytes[ADDRESS_OFFSET .. ADDRESS_OFFSET + ADDRESS_LEN]);
+        std.mem.writeInt(u64, address_key[ADDRESS_LEN .. ADDRESS_LEN + TIMESTAMP_BYTES], timestamp, .big);
+        std.mem.copyForwards(u8, address_key[ADDRESS_LEN + TIMESTAMP_BYTES ..], id_slice);
+        try address_db.delete(address_key[0..]);
+
+        var kind_key: [KIND_BYTES + TIMESTAMP_BYTES + ID_LEN]u8 = undefined;
+        std.mem.writeInt(u64, kind_key[0..KIND_BYTES], rec.kind(), .big);
+        std.mem.writeInt(u64, kind_key[KIND_BYTES .. KIND_BYTES + TIMESTAMP_BYTES], timestamp, .big);
+        std.mem.copyForwards(u8, kind_key[KIND_BYTES + TIMESTAMP_BYTES ..], id_slice);
+        try kind_db.delete(kind_key[0..]);
+    }
+};
+
+pub const OwnedRecord = struct {
+    bytes: []u8,
+
+    pub fn slice(self: OwnedRecord) []const u8 {
+        return self.bytes;
+    }
+};
+
+pub const RecordList = struct {
+    allocator: std.mem.Allocator,
+    items: []OwnedRecord,
+
+    pub fn empty(allocator: std.mem.Allocator) RecordList {
+        return .{ .allocator = allocator, .items = &[_]OwnedRecord{} };
+    }
+
+    pub fn deinit(self: RecordList) void {
+        for (self.items) |item| {
+            self.allocator.free(item.bytes);
+        }
+        if (self.items.len > 0) self.allocator.free(self.items);
+    }
+};
+
+const RecordListBuilder = struct {
+    allocator: std.mem.Allocator,
+    list: std.ArrayList(OwnedRecord),
+
+    fn init(allocator: std.mem.Allocator) RecordListBuilder {
+        return .{ .allocator = allocator, .list = .{} };
+    }
+
+    fn append(self: *RecordListBuilder, bytes: []u8) !void {
+        try self.list.append(self.allocator, .{ .bytes = bytes });
+    }
+
+    fn len(self: RecordListBuilder) usize {
+        return self.list.items.len;
+    }
+
+    fn toList(self: *RecordListBuilder) !RecordList {
+        const items = try self.list.toOwnedSlice(self.allocator);
+        return .{ .allocator = self.allocator, .items = items };
+    }
+
+    fn deinit(self: *RecordListBuilder) void {
+        for (self.list.items) |item| {
+            self.allocator.free(item.bytes);
+        }
+        self.list.deinit(self.allocator);
+    }
+};
+
+fn copyRecord(allocator: std.mem.Allocator, db: lmdb.Database, id: []const u8) Error![]u8 {
+    const value = try db.get(id) orelse return error.DataCorruption;
+    return allocator.dupe(u8, value);
+}
+
+test "storage put and fetch by id" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("db");
+    const db_path = try tmp.dir.realpathAlloc(allocator, "db");
+    defer allocator.free(db_path);
+
+    var storage = try Storage.init(allocator, .{ .path = db_path });
+    defer storage.deinit();
+
+    const record_bytes = try loadTestRecord(allocator);
+    defer allocator.free(record_bytes);
+
+    try storage.put(record_bytes);
+
+    const maybe = try storage.getById(allocator, record_bytes[0..ID_LEN]);
+    defer if (maybe) |value| allocator.free(value);
+    try std.testing.expect(maybe != null);
+    try std.testing.expectEqualSlices(u8, record_bytes, maybe.?);
+}
+
+test "storage indexes by address kind timestamp" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("db");
+    const db_path = try tmp.dir.realpathAlloc(allocator, "db");
+    defer allocator.free(db_path);
+
+    var storage = try Storage.init(allocator, .{ .path = db_path });
+    defer storage.deinit();
+
+    const record_bytes = try loadTestRecord(allocator);
+    defer allocator.free(record_bytes);
+    const rec = try Record.fromBytes(record_bytes);
+
+    try storage.put(record_bytes);
+
+    var by_address = try storage.getByAddress(allocator, rec.bytes[ADDRESS_OFFSET .. ADDRESS_OFFSET + ADDRESS_LEN], 5);
+    defer by_address.deinit();
+    try std.testing.expectEqual(@as(usize, 1), by_address.items.len);
+    try std.testing.expectEqualSlices(u8, record_bytes, by_address.items[0].bytes);
+
+    var by_kind = try storage.getByKind(allocator, rec.kind(), rec.timestamp(), rec.timestamp(), 5);
+    defer by_kind.deinit();
+    try std.testing.expectEqual(@as(usize, 1), by_kind.items.len);
+    try std.testing.expectEqualSlices(u8, record_bytes, by_kind.items[0].bytes);
+
+    var by_timestamp = try storage.getByTimestamp(allocator, rec.timestamp(), rec.timestamp(), 5);
+    defer by_timestamp.deinit();
+    try std.testing.expectEqual(@as(usize, 1), by_timestamp.items.len);
+    try std.testing.expectEqualSlices(u8, record_bytes, by_timestamp.items[0].bytes);
+}
+
+test "storage delete removes indexes" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("db");
+    const db_path = try tmp.dir.realpathAlloc(allocator, "db");
+    defer allocator.free(db_path);
+
+    var storage = try Storage.init(allocator, .{ .path = db_path });
+    defer storage.deinit();
+
+    const record_bytes = try loadTestRecord(allocator);
+    defer allocator.free(record_bytes);
+
+    try storage.put(record_bytes);
+    const deleted = try storage.delete(record_bytes[0..ID_LEN]);
+    try std.testing.expect(deleted);
+
+    const maybe = try storage.getById(allocator, record_bytes[0..ID_LEN]);
+    defer if (maybe) |value| allocator.free(value);
+    try std.testing.expect(maybe == null);
+}
+
+fn loadTestRecord(allocator: std.mem.Allocator) ![]u8 {
+    const json_bytes = try std.fs.cwd().readFileAlloc(allocator, "testdata/test_vectors.json", 1 << 20);
+    defer allocator.free(json_bytes);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{});
+    defer parsed.deinit();
+
+    const record_hex_value = parsed.value.object.get("record").?.object.get("record_hex").?;
+    const record_hex = record_hex_value.string;
+    return hexToBytesAlloc(allocator, record_hex);
+}
+
+fn hexToBytesAlloc(allocator: std.mem.Allocator, hex: []const u8) ![]u8 {
+    if (hex.len % 2 != 0) return error.InvalidKeyLength;
+    const out = try allocator.alloc(u8, hex.len / 2);
+    errdefer allocator.free(out);
+    _ = try std.fmt.hexToBytes(out, hex);
+    return out;
+}


### PR DESCRIPTION
## Summary
- add a minimal LMDB binding (src/lmdb.zig) and wire it into the build
- implement the storage MVP with id/address/kind/timestamp indexes and basic tests
- drop the old vendored zig-lmdb wrapper now that we have a local binding

## Testing
- zig build test