### PR TITLE
Refactor CI routine into script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,51 +17,39 @@
         pkgs = import nixpkgs {
           inherit system overlays;
         };
+        inherit (pkgs) mkShell stdenv;
         zigPkg = pkgs.zigpkgs."0.15.1"; # Keep toolchain pinned to Zig 0.15.1 for reproducibility.
         zlsPkg = pkgs.zls; # Ships Zig Language Server (0.15.0) from the same nixpkgs revision.
         cargoPkg = pkgs.cargo;
-        dollar = "\$";
-        ciScript = pkgs.writeShellScriptBin "mosaic-ci" ''
-          set -euo pipefail
-          cleanup_dir=""
-          if [ -z "${dollar}{TMPDIR:-}" ]; then
-            cleanup_dir="$(mktemp -d)"
-            TMPDIR="$cleanup_dir"
-            export TMPDIR
-            trap 'rm -rf "$cleanup_dir"' EXIT
-          fi
-          export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global-cache"
-          export ZIG_LOCAL_CACHE_DIR="$ZIG_GLOBAL_CACHE_DIR"
-          mkdir -p "$ZIG_GLOBAL_CACHE_DIR"
-          ${zigPkg}/bin/zig fmt --check build.zig build.zig.zon src
-          ${zigPkg}/bin/zig build
-          ${zigPkg}/bin/zig build test
-          (cd test-vectors && ${cargoPkg}/bin/cargo check)
+        zigBuildCacheEnv = ''
+          export ZIG_GLOBAL_CACHE_DIR=$TMPDIR/zig-global-cache
+          export ZIG_LOCAL_CACHE_DIR=$TMPDIR/zig-cache
         '';
+        ciScript = pkgs.writeShellApplication {
+          name = "mosaic-ci";
+          runtimeInputs = [ zigPkg cargoPkg pkgs.coreutils ];
+          text = builtins.readFile ./scripts/ci.sh;
+        };
       in {
-        packages.default = pkgs.stdenv.mkDerivation {
+        packages.default = stdenv.mkDerivation {
           pname = "mosaic-zig";
           version = "0.1.0";
           src = ./.;
           nativeBuildInputs = [ zigPkg pkgs.pkg-config ];
           dontConfigure = true;
-          buildPhase = ''
-            export ZIG_GLOBAL_CACHE_DIR=$TMPDIR/zig-global-cache
-            export ZIG_LOCAL_CACHE_DIR=$TMPDIR/zig-cache
+          buildPhase = zigBuildCacheEnv + ''
             ${zigPkg}/bin/zig build install --prefix $out -Doptimize=ReleaseSafe
           '';
           installPhase = "true";
           doCheck = true;
-          checkPhase = ''
-            export ZIG_GLOBAL_CACHE_DIR=$TMPDIR/zig-global-cache
-            export ZIG_LOCAL_CACHE_DIR=$TMPDIR/zig-cache
+          checkPhase = zigBuildCacheEnv + ''
             ${zigPkg}/bin/zig build test
           '';
         };
 
         packages.zls = zlsPkg;
 
-        devShells.default = pkgs.mkShell {
+        devShells.default = mkShell {
           buildInputs = [ zigPkg pkgs.pkg-config zlsPkg cargoPkg pkgs.rustc pkgs.clang pkgs.libclang pkgs.gcc-unwrapped ];
           shellHook = ''
             export ZIG_GLOBAL_CACHE_DIR=$PWD/.zig-cache

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup_dir=""
+if [ -z "${TMPDIR:-}" ]; then
+  cleanup_dir="$(mktemp -d)"
+  TMPDIR="$cleanup_dir"
+  export TMPDIR
+  trap 'rm -rf "$cleanup_dir"' EXIT
+fi
+
+export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="$ZIG_GLOBAL_CACHE_DIR"
+mkdir -p "$ZIG_GLOBAL_CACHE_DIR"
+
+zig fmt --check build.zig build.zig.zon src
+zig build
+zig build test
+(
+  cd test-vectors
+  cargo check
+)


### PR DESCRIPTION
## Summary
- move the CI routine out of flake.nix into scripts/ci.sh for readability
- reuse a shared Zig cache export block for build and check phases
- wrap the new script with writeShellApplication for nix run parity

## Testing
- nix run .#ci
