### PR TITLE
feat: add websocket handler integration

### DIFF
--- a/src/transport/websocket_mosaic.zig
+++ b/src/transport/websocket_mosaic.zig
@@ -1,5 +1,10 @@
 const std = @import("std");
 const websocket = @import("websocket");
+const mosaic = @import("mosaic");
+const protocol = mosaic.protocol;
+const Ed25519Blake3 = mosaic.Ed25519Blake3;
+const printable = mosaic.printable;
+const mock_server = @import("websocket_server.zig");
 const ascii = std.ascii;
 
 pub const ConnectOptions = struct {
@@ -11,6 +16,7 @@ pub const ConnectOptions = struct {
     versions: []const u8 = "0",
     features: []const u8 = "",
     authenticate_as: ?[]const u8 = null,
+    authenticate_secret: ?[]const u8 = null,
     server_auth_nonce: ?[]const u8 = null,
     ca_bundle: ?std.crypto.Certificate.Bundle = null,
     host_header: ?[]const u8 = null,
@@ -18,16 +24,59 @@ pub const ConnectOptions = struct {
 };
 
 pub const Connection = struct {
+    allocator: std.mem.Allocator,
     client: websocket.Client,
     handshake: websocket.Client.HandshakeResult,
+    hello_state: HelloState,
 
     pub fn deinit(self: *Connection) void {
+        self.hello_state.deinit(self.allocator);
         self.handshake.deinit();
         self.client.deinit();
     }
 
     pub fn helloAck(self: *Connection) !HelloAck {
-        return parseHelloAck(&self.handshake);
+        return self.hello_state.headers;
+    }
+
+    pub fn helloState(self: *const Connection) *const HelloState {
+        return &self.hello_state;
+    }
+
+    fn requiresHelloAuth(self: *const Connection) bool {
+        return self.hello_state.requiresHelloAuth();
+    }
+
+    pub fn sendMessage(self: *Connection, message: *const protocol.Message) !void {
+        const bytes = try protocol.encodeMessage(self.allocator, message.*);
+        defer self.allocator.free(bytes);
+        try self.client.writeBin(bytes);
+    }
+
+    pub fn recvMessage(self: *Connection) !protocol.Message {
+        while (true) {
+            const ws_message = try self.client.read() orelse continue;
+            defer self.client.done(ws_message);
+
+            switch (ws_message.type) {
+                .binary => {
+                    const decoded = try protocol.decodeMessage(self.allocator, ws_message.data);
+                    if (decoded.messageType() == protocol.MessageType.hello_ack) {
+                        try self.hello_state.setHelloAck(self.allocator, decoded.hello_ack);
+                    }
+                    return decoded;
+                },
+                .ping => {
+                    const payload = try self.allocator.dupe(u8, ws_message.data);
+                    defer self.allocator.free(payload);
+                    try self.client.writePong(payload);
+                    continue;
+                },
+                .pong => continue,
+                .close => return error.ConnectionClosed,
+                .text => return error.UnexpectedTextFrame,
+            }
+        }
     }
 };
 
@@ -38,6 +87,114 @@ pub const HelloAck = struct {
     server_authentication: ?[]const u8 = null,
     client_authenticate_nonce: ?[]const u8 = null,
     service_url: ?[]const u8 = null,
+};
+
+pub const HelloState = struct {
+    headers: HelloAck,
+    authenticate_as: ?[]u8 = null,
+    hello_auth_sent: bool = false,
+    ack_frame: ?AckFrame = null,
+    auth: ?*ClientAuth = null,
+
+    const AckFrame = struct {
+        result: protocol.ResultCode,
+        max_version: u8,
+        applications: []u32,
+    };
+
+    const ClientAuth = struct {
+        key_pair: Ed25519Blake3.KeyPair,
+    };
+
+    fn init(
+        allocator: std.mem.Allocator,
+        handshake_ack: HelloAck,
+        options: ConnectOptions,
+    ) !HelloState {
+        var auth_copy: ?[]u8 = null;
+        if (options.authenticate_as) |auth| {
+            auth_copy = try allocator.dupe(u8, auth);
+        }
+
+        var auth_state: ?*ClientAuth = null;
+
+        if (handshake_ack.client_authenticate_nonce != null) {
+            if (options.authenticate_secret == null) {
+                if (auth_copy) |copy| allocator.free(copy);
+                return error.HelloAuthMissingSecret;
+            }
+            if (options.authenticate_as == null) {
+                if (auth_copy) |copy| allocator.free(copy);
+                return error.HelloAuthMissingPublicKey;
+            }
+        }
+
+        if (options.authenticate_secret) |secret_text| {
+            if (options.authenticate_as == null) {
+                if (auth_copy) |copy| allocator.free(copy);
+                return error.HelloAuthMissingPublicKey;
+            }
+
+            var seed = try printable.decodeSecretKey(secret_text);
+            defer @memset(seed[0..], 0);
+
+            var key_pair = try Ed25519Blake3.KeyPair.fromSeed(seed);
+            const derived_public = key_pair.publicKeyBytes();
+            const expected_public = try printable.decodeUserPublicKey(options.authenticate_as.?);
+            if (!std.mem.eql(u8, derived_public[0..], expected_public[0..])) {
+                zeroKeyPair(&key_pair);
+                if (auth_copy) |copy| allocator.free(copy);
+                return error.HelloAuthPublicMismatch;
+            }
+
+            const auth_ptr = try allocator.create(ClientAuth);
+            errdefer allocator.destroy(auth_ptr);
+            auth_ptr.* = .{ .key_pair = key_pair };
+            auth_state = auth_ptr;
+        }
+
+        return HelloState{
+            .headers = handshake_ack,
+            .authenticate_as = auth_copy,
+            .auth = auth_state,
+        };
+    }
+
+    fn deinit(self: *HelloState, allocator: std.mem.Allocator) void {
+        if (self.ack_frame) |*ack| {
+            allocator.free(ack.applications);
+            self.ack_frame = null;
+        }
+        if (self.authenticate_as) |auth| {
+            allocator.free(auth);
+            self.authenticate_as = null;
+        }
+        if (self.auth) |auth_ptr| {
+            zeroKeyPair(&auth_ptr.key_pair);
+            allocator.destroy(auth_ptr);
+            self.auth = null;
+        }
+    }
+
+    fn setHelloAck(self: *HelloState, allocator: std.mem.Allocator, ack: protocol.HelloAck) !void {
+        const apps = try allocator.alloc(u32, ack.applications.len);
+        std.mem.copyForwards(u32, apps, ack.applications);
+
+        const new_frame = AckFrame{
+            .result = ack.result,
+            .max_version = ack.max_version,
+            .applications = apps,
+        };
+
+        if (self.ack_frame) |*existing| {
+            allocator.free(existing.applications);
+        }
+        self.ack_frame = new_frame;
+    }
+
+    fn requiresHelloAuth(self: *const HelloState) bool {
+        return self.headers.client_authenticate_nonce != null and !self.hello_auth_sent;
+    }
 };
 
 pub const HelloAckError = error{
@@ -68,10 +225,21 @@ pub fn connect(
     });
     errdefer handshake.deinit();
 
-    return .{
+    const handshake_headers = try parseHelloAck(&handshake);
+    var connection = Connection{
+        .allocator = allocator,
         .client = client,
         .handshake = handshake,
+        .hello_state = undefined,
     };
+    connection.hello_state = try HelloState.init(allocator, handshake_headers, options);
+    errdefer connection.deinit();
+
+    if (connection.requiresHelloAuth()) {
+        try sendHelloAuth(&connection);
+    }
+
+    return connection;
 }
 
 fn buildHandshakeHeaders(
@@ -119,6 +287,50 @@ fn listWrite(ctx: *ArrayListWriter, bytes: []const u8) error{OutOfMemory}!usize 
 }
 
 const ListWriter = std.io.GenericWriter(*ArrayListWriter, error{OutOfMemory}, listWrite);
+
+fn zeroKeyPair(key_pair: *Ed25519Blake3.KeyPair) void {
+    @memset(key_pair.inner.secret_key.bytes[0..], 0);
+    @memset(key_pair.inner.public_key.bytes[0..], 0);
+}
+
+fn writeHelloAuthFrame(self: *Connection, payload: []const u8) !void {
+    const type_byte: u8 = 0x11;
+    const header_len = 8;
+    const total_len = header_len + payload.len;
+    const len_u32 = std.math.cast(u32, total_len) orelse return error.HelloAuthTooLong;
+
+    var frame = try self.allocator.alloc(u8, total_len);
+    defer self.allocator.free(frame);
+
+    frame[0] = type_byte;
+    frame[1] = 0;
+    frame[2] = 0;
+    frame[3] = 0;
+    std.mem.writeInt(u32, frame[4..8], len_u32, .little);
+    std.mem.copyForwards(u8, frame[8..], payload);
+
+    try self.client.writeBin(frame);
+}
+
+fn encodeHelloAuthPayload(self: *Connection) ![]u8 {
+    const nonce = self.hello_state.headers.client_authenticate_nonce orelse return error.HelloAuthMissingChallenge;
+    if (nonce.len == 0) return error.HelloAuthMissingChallenge;
+
+    const auth = self.hello_state.auth orelse return error.HelloAuthMissingSecret;
+    const signature = try auth.key_pair.sign(nonce);
+
+    const payload = try self.allocator.alloc(u8, signature.len);
+    std.mem.copyForwards(u8, payload, signature[0..]);
+    return payload;
+}
+
+fn sendHelloAuth(self: *Connection) !void {
+    if (!self.requiresHelloAuth()) return;
+    const payload = try encodeHelloAuthPayload(self);
+    defer self.allocator.free(payload);
+    try writeHelloAuthFrame(self, payload);
+    self.hello_state.hello_auth_sent = true;
+}
 
 pub fn parseHelloAck(handshake: *const websocket.Client.HandshakeResult) HelloAckError!HelloAck {
     const version = handshake.get("x-mosaic-version") orelse return error.MissingServerVersion;
@@ -181,125 +393,49 @@ test "parseHelloAck extracts Mosaic headers" {
     try testing.expect(hello.service_url == null);
 }
 
-const ExpectHeaders = struct {
-    versions: []const u8,
-    features: []const u8,
-    subprotocol: []const u8 = "mosaic2025",
-};
-
-const ServerResult = struct {
-    saw_versions: bool = false,
-    saw_features: bool = false,
-    saw_subprotocol: bool = false,
-};
-
-const ServerContext = struct {
-    server: *std.net.Server,
-    expect: ExpectHeaders,
-    result: ServerResult = .{},
-    err: ?anyerror = null,
-};
-
-fn serverThread(ctx: *ServerContext) void {
-    ctx.result = .{};
-    ctx.err = null;
-    const res = runMockServer(ctx.server, ctx.expect) catch |err| {
-        ctx.err = err;
-        return;
-    };
-    ctx.result = res;
-}
-
-fn runMockServer(server: *std.net.Server, expect: ExpectHeaders) !ServerResult {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    var connection = try server.accept();
-    defer connection.stream.close();
-
-    var buffer = std.ArrayListUnmanaged(u8){};
-    defer buffer.deinit(arena.allocator());
-
-    var tmp: [512]u8 = undefined;
-    while (true) {
-        const read_len = try connection.stream.read(&tmp);
-        if (read_len == 0) return error.ConnectionClosedEarly;
-        try buffer.appendSlice(arena.allocator(), tmp[0..read_len]);
-        if (std.mem.indexOf(u8, buffer.items, "\r\n\r\n")) |_| break;
-    }
-
-    var saw_versions = false;
-    var saw_features = false;
-    var saw_subprotocol = false;
-    var sec_key: ?[]const u8 = null;
-
-    var lines = std.mem.splitSequence(u8, buffer.items, "\r\n");
-    _ = lines.next() orelse return error.InvalidHandshakeRequest;
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
-        const colon_index = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const name = std.mem.trim(u8, line[0..colon_index], &ascii.whitespace);
-        const value = std.mem.trim(u8, line[colon_index + 1 ..], &ascii.whitespace);
-
-        if (ascii.eqlIgnoreCase(name, "sec-websocket-key")) {
-            sec_key = value;
-        } else if (ascii.eqlIgnoreCase(name, "sec-websocket-protocol")) {
-            saw_subprotocol = ascii.eqlIgnoreCase(value, expect.subprotocol);
-        } else if (ascii.eqlIgnoreCase(name, "x-mosaic-versions")) {
-            saw_versions = std.mem.eql(u8, value, expect.versions);
-        } else if (ascii.eqlIgnoreCase(name, "x-mosaic-features")) {
-            saw_features = std.mem.eql(u8, value, expect.features);
-        }
-    }
-
-    const websocket_key = sec_key orelse return error.MissingWebSocketKey;
-    var sha = std.crypto.hash.Sha1.init(.{});
-    sha.update(websocket_key);
-    sha.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
-    var digest: [std.crypto.hash.Sha1.digest_length]u8 = undefined;
-    sha.final(&digest);
-
-    var accept_buf: [28]u8 = undefined;
-    const accept_value = std.base64.standard.Encoder.encode(&accept_buf, &digest);
-
-    var response_builder = std.ArrayListUnmanaged(u8){};
-    defer response_builder.deinit(arena.allocator());
-    var response_writer_ctx = ArrayListWriter{ .list = &response_builder, .allocator = arena.allocator() };
-    const response_writer = ListWriter{ .context = &response_writer_ctx };
-
-    try std.fmt.format(
-        response_writer,
-        "HTTP/1.1 101 Switching Protocol\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {s}\r\nSec-WebSocket-Protocol: {s}\r\n" ++
-            "X-Mosaic-Version: 0\r\nX-Mosaic-Features-Accepted: chat\r\nX-Mosaic-Server-Authentication: sig\r\n" ++
-            "X-Mosaic-Client-Authenticate-Nonce: nonce\r\n\r\n",
-        .{ accept_value, expect.subprotocol },
-    );
-
-    try connection.stream.writeAll(response_builder.items);
-
-    return ServerResult{
-        .saw_versions = saw_versions,
-        .saw_features = saw_features,
-        .saw_subprotocol = saw_subprotocol,
-    };
-}
-
 test "websocket mosaic handshake demo" {
-    var address = try std.net.Address.parseIp("127.0.0.1", 0);
-    var server = try address.listen(.{ .reuse_address = true });
-    defer server.deinit();
+    const allocator = std.testing.allocator;
 
-    const port = server.listen_address.in.getPort();
-    const expect = ExpectHeaders{ .versions = "0,1", .features = "chat" };
+    const secret_text = "mosec06ayb687prmw8abtuum9bps5hjmfz5ffyft3b4jeznn3htppf3kto";
+    var seed = try printable.decodeSecretKey(secret_text);
+    var kp = try Ed25519Blake3.KeyPair.fromSeed(seed);
+    defer zeroKeyPair(&kp);
+    @memset(seed[0..], 0);
+    const public_bytes = kp.publicKeyBytes();
+    var public_text = printable.encodeUserPublicKey(public_bytes);
 
-    var ctx = ServerContext{ .server = &server, .expect = expect };
-    const thread = try std.Thread.spawn(.{}, serverThread, .{&ctx});
+    const apps = [_]u32{0};
+    var submission_prefix = [_]u8{0} ** 32;
+    submission_prefix[0] = 0x01;
 
-    var conn = try connect(std.testing.allocator, "127.0.0.1", .{
-        .port = port,
-        .versions = expect.versions,
-        .features = expect.features,
+    var server = try mock_server.start(allocator, .{
+        .expect = .{
+            .versions = "0,1",
+            .features = "chat",
+            .authenticate_as = public_text[0..],
+            .server_auth_nonce = "nonce123",
+        },
+        .response = .{
+            .version = "0",
+            .features_accepted = "chat",
+            .server_authentication = "sig",
+            .client_auth_nonce = "client-nonce",
+            .hello_ack_result = protocol.ResultCode.success,
+            .hello_ack_max_version = 0,
+            .hello_ack_applications = apps[0..],
+            .submission_result_prefix = submission_prefix,
+        },
+    });
+    defer server.ensureStopped();
+
+    var conn = try connect(allocator, "127.0.0.1", .{
+        .port = server.port(),
+        .versions = "0,1",
+        .features = "chat",
         .host_header = "127.0.0.1",
+        .authenticate_as = public_text[0..],
+        .authenticate_secret = secret_text,
+        .server_auth_nonce = "nonce123",
     });
     defer conn.deinit();
 
@@ -307,12 +443,32 @@ test "websocket mosaic handshake demo" {
     try std.testing.expectEqualStrings("0", hello.version);
     try std.testing.expectEqualStrings("chat", hello.features_accepted.?);
     try std.testing.expectEqualStrings("sig", hello.server_authentication.?);
-    try std.testing.expectEqualStrings("nonce", hello.client_authenticate_nonce.?);
+    try std.testing.expectEqualStrings("client-nonce", hello.client_authenticate_nonce.?);
 
-    thread.join();
-    if (ctx.err) |err| return err;
-    const server_result = ctx.result;
+    try std.testing.expect(conn.helloState().hello_auth_sent);
+    try std.testing.expect(conn.helloState().authenticate_as != null);
+    try std.testing.expectEqualStrings(public_text[0..], conn.helloState().authenticate_as.?);
+    try std.testing.expect(conn.helloState().ack_frame == null);
+
+    var first = try conn.recvMessage();
+    defer first.deinit(allocator);
+    try std.testing.expectEqual(protocol.MessageType.hello_ack, first.messageType());
+    const ack_summary = conn.helloState().ack_frame.?;
+    try std.testing.expectEqual(protocol.ResultCode.success, ack_summary.result);
+    try std.testing.expectEqual(@as(u8, 0), ack_summary.max_version);
+    try std.testing.expectEqual(@as(usize, 1), ack_summary.applications.len);
+    try std.testing.expectEqual(@as(u32, 0), ack_summary.applications[0]);
+
+    var second = try conn.recvMessage();
+    defer second.deinit(allocator);
+    try std.testing.expectEqual(protocol.MessageType.submission_result, second.messageType());
+
+    const server_result = try server.wait();
     try std.testing.expect(server_result.saw_versions);
     try std.testing.expect(server_result.saw_features);
     try std.testing.expect(server_result.saw_subprotocol);
+    try std.testing.expect(server_result.saw_authenticate_as);
+    try std.testing.expect(server_result.saw_server_nonce);
+    try std.testing.expect(server_result.hello_auth_seen);
+    try std.testing.expect(server_result.hello_auth_valid);
 }

--- a/src/transport/websocket_server.zig
+++ b/src/transport/websocket_server.zig
@@ -1,29 +1,16 @@
 const std = @import("std");
+const websocket = @import("websocket");
 const mosaic = @import("mosaic");
 const protocol = mosaic.protocol;
-const Ed25519Blake3 = mosaic.Ed25519Blake3;
 const printable = mosaic.printable;
-const ascii = std.ascii;
-
-const ServerError = error{
-    InvalidHandshakeRequest,
-    ConnectionClosedEarly,
-    MissingWebSocketKey,
-    InvalidAuthenticateHeader,
-    MissingAuthenticateHeader,
-    MissingHelloAuthPayload,
-    UnexpectedOpCode,
-    UnmaskedFrame,
-    FrameTooLarge,
-    InvalidHelloAuthPayload,
-};
+const Ed25519Blake3 = mosaic.Ed25519Blake3;
 
 pub const ExpectHeaders = struct {
     versions: []const u8,
     features: []const u8,
-    subprotocol: []const u8 = "mosaic2025",
     authenticate_as: ?[]const u8 = null,
     server_auth_nonce: ?[]const u8 = null,
+    subprotocol: []const u8 = "mosaic2025",
 };
 
 pub const ResponseConfig = struct {
@@ -52,272 +39,319 @@ pub const ServerResult = struct {
     hello_auth_valid: bool = false,
 };
 
-const ServerContext = struct {
-    server: std.net.Server,
-    config: Config,
-    result: ServerResult = .{},
-    err: ?anyerror = null,
-    port: u16,
+const ServerError = error{
+    MissingHeader,
+    InvalidHeader,
+    MissingAuthenticateHeader,
+    InvalidAuthenticateHeader,
+    MissingHelloAuthPayload,
+    InvalidHelloAuthPayload,
 };
 
-pub const Server = struct {
-    ctx: ?*ServerContext,
-    thread: std.Thread,
+const HandlerState = struct {
     allocator: std.mem.Allocator,
+    config: Config,
+    result: ServerResult = .{},
+    expect_public_key: ?[32]u8,
+    records: std.AutoHashMap([48]u8, []u8),
+    mutex: std.Thread.Mutex = .{},
+
+    fn init(allocator: std.mem.Allocator, config: Config) !*HandlerState {
+        const state = try allocator.create(HandlerState);
+        errdefer allocator.destroy(state);
+
+        var expect_public: ?[32]u8 = null;
+        if (config.expect.authenticate_as) |text| {
+            const decoded = printable.decodeUserPublicKey(text) catch return ServerError.InvalidAuthenticateHeader;
+            expect_public = decoded;
+        }
+
+        state.* = .{
+            .allocator = allocator,
+            .config = config,
+            .result = .{},
+            .expect_public_key = expect_public,
+            .records = std.AutoHashMap([48]u8, []u8).init(allocator),
+        };
+        return state;
+    }
+
+    fn deinit(self: *HandlerState) void {
+        var it = self.records.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.records.deinit();
+    }
+
+    fn noteHandshake(self: *HandlerState, result: ServerResult) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.result = result;
+    }
+
+    fn noteHelloAuth(self: *HandlerState, valid: bool) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.result.hello_auth_seen = true;
+        self.result.hello_auth_valid = valid;
+    }
+};
+
+const Handler = struct {
+    state: *HandlerState,
+    conn: *websocket.server.Conn,
+    authenticated: bool = false,
+    expect_hello_auth: bool,
+
+    pub fn init(handshake: *const websocket.server.Handshake, conn: *websocket.server.Conn, state: *HandlerState) !Handler {
+        const expect = state.config.expect;
+        var result = ServerResult{};
+
+        const versions = handshake.headers.get("x-mosaic-versions") orelse return ServerError.MissingHeader;
+        result.saw_versions = std.mem.eql(u8, versions, expect.versions);
+        if (!result.saw_versions) return ServerError.InvalidHeader;
+
+        const features = handshake.headers.get("x-mosaic-features") orelse return ServerError.MissingHeader;
+        result.saw_features = std.mem.eql(u8, features, expect.features);
+        if (!result.saw_features) return ServerError.InvalidHeader;
+
+        const subprotocol = handshake.headers.get("sec-websocket-protocol") orelse return ServerError.MissingHeader;
+        result.saw_subprotocol = std.mem.eql(u8, subprotocol, expect.subprotocol);
+        if (!result.saw_subprotocol) return ServerError.InvalidHeader;
+
+        if (expect.server_auth_nonce) |nonce| {
+            const header = handshake.headers.get("x-mosaic-server-authenticate-nonce") orelse return ServerError.MissingHeader;
+            result.saw_server_nonce = std.mem.eql(u8, header, nonce);
+            if (!result.saw_server_nonce) return ServerError.InvalidHeader;
+        } else {
+            result.saw_server_nonce = true;
+        }
+
+        if (expect.authenticate_as) |expected| {
+            const header = handshake.headers.get("x-mosaic-authenticate-as") orelse return ServerError.MissingAuthenticateHeader;
+            result.saw_authenticate_as = std.mem.eql(u8, header, expected);
+            if (!result.saw_authenticate_as) return ServerError.InvalidAuthenticateHeader;
+            const decoded = printable.decodeUserPublicKey(header) catch return ServerError.InvalidAuthenticateHeader;
+            state.expect_public_key = decoded;
+        } else {
+            result.saw_authenticate_as = true;
+        }
+
+        // Populate response headers
+        handshake.res_headers.add("Sec-WebSocket-Protocol", expect.subprotocol);
+        handshake.res_headers.add("X-Mosaic-Version", state.config.response.version);
+        handshake.res_headers.add("X-Mosaic-Features-Accepted", state.config.response.features_accepted);
+        handshake.res_headers.add("X-Mosaic-Server-Authentication", state.config.response.server_authentication);
+        handshake.res_headers.add("X-Mosaic-Client-Authenticate-Nonce", state.config.response.client_auth_nonce);
+
+        state.noteHandshake(result);
+
+        return Handler{
+            .state = state,
+            .conn = conn,
+            .expect_hello_auth = state.config.response.client_auth_nonce.len != 0,
+        };
+    }
+
+    pub fn afterInit(self: *Handler, _: *HandlerState) !void {
+        try self.sendHelloAck();
+    }
+
+    pub fn clientMessage(self: *Handler, allocator: std.mem.Allocator, data: []const u8) !void {
+        if (data.len == 0) return;
+        const msg_type = data[0];
+        if (msg_type == 0x11) {
+            try self.handleHelloAuth(data);
+            return;
+        }
+
+        var message = try protocol.decodeMessage(allocator, data);
+        defer message.deinit(allocator);
+
+        switch (message) {
+            .submission => |submission| try self.handleSubmission(submission),
+            .get => |get| try self.handleGet(get),
+            else => {},
+        }
+    }
+
+    fn sendHelloAck(self: *Handler) !void {
+        const res = self.state.config.response;
+        const allocator = self.state.allocator;
+        var apps = try allocator.alloc(u32, res.hello_ack_applications.len);
+        defer allocator.free(apps);
+        @memcpy(apps[0..], res.hello_ack_applications);
+
+        const message = protocol.Message{ .hello_ack = .{
+            .result = res.hello_ack_result,
+            .max_version = res.hello_ack_max_version,
+            .applications = apps,
+        } };
+
+        const encoded = try protocol.encodeMessage(allocator, message);
+        defer allocator.free(encoded);
+        try self.conn.writeFrame(.binary, encoded);
+    }
+
+    fn handleHelloAuth(self: *Handler, payload: []const u8) !void {
+        if (!self.expect_hello_auth) {
+            self.state.noteHelloAuth(false);
+            return;
+        }
+        if (payload.len != 8 + Ed25519Blake3.signature_length) {
+            self.state.noteHelloAuth(false);
+            return ServerError.InvalidHelloAuthPayload;
+        }
+        const nonce = self.state.config.response.client_auth_nonce;
+        if (nonce.len == 0) {
+            self.state.noteHelloAuth(false);
+            return ServerError.InvalidHelloAuthPayload;
+        }
+
+        const signature = payload[8..];
+        const public_key = self.state.expect_public_key orelse return ServerError.MissingAuthenticateHeader;
+        var sig: [Ed25519Blake3.signature_length]u8 = undefined;
+        @memcpy(sig[0..], signature);
+        try Ed25519Blake3.verify(nonce, sig, public_key);
+        self.state.noteHelloAuth(true);
+        self.authenticated = true;
+    }
+
+    fn handleSubmission(self: *Handler, submission: protocol.Submission) !void {
+        if (self.expect_hello_auth and !self.authenticated) {
+            return;
+        }
+        const allocator = self.state.allocator;
+        const record_bytes = submission.record_bytes;
+        var copy = try allocator.alloc(u8, record_bytes.len);
+        @memcpy(copy, record_bytes);
+
+        var id: [48]u8 = undefined;
+        @memcpy(id[0..], copy[0..48]);
+
+        {
+            self.state.mutex.lock();
+            defer self.state.mutex.unlock();
+            if (try self.state.records.fetchPut(id, copy)) |older| {
+                allocator.free(older.value);
+            }
+        }
+
+        var prefix = [_]u8{0} ** 32;
+        @memcpy(prefix[0..], copy[0..32]);
+        const message = protocol.Message{ .submission_result = .{
+            .result = protocol.ResultCode.accepted,
+            .id_prefix = prefix,
+        } };
+        const encoded = try protocol.encodeMessage(allocator, message);
+        defer allocator.free(encoded);
+        try self.conn.writeFrame(.binary, encoded);
+    }
+
+    fn handleGet(self: *Handler, get: protocol.Get) !void {
+        var i: usize = 0;
+        while (i < get.references.len) : (i += 1) {
+            const key = get.references[i].bytes;
+            var record_slice_opt: ?[]u8 = null;
+            {
+                self.state.mutex.lock();
+                defer self.state.mutex.unlock();
+                if (self.state.records.get(key)) |value| {
+                    record_slice_opt = value;
+                }
+            }
+            const record_slice = record_slice_opt orelse continue;
+            const record = protocol.Record.fromBytes(record_slice) catch continue;
+            const message = protocol.Message{ .record = .{
+                .query_id = get.query_id,
+                .record_bytes = record_slice,
+                .record = record,
+            } };
+            const encoded = try protocol.encodeMessage(self.state.allocator, message);
+            defer self.state.allocator.free(encoded);
+            try self.conn.writeFrame(.binary, encoded);
+        }
+    }
+};
+
+const WsServer = websocket.server.Server(Handler);
+
+fn findOpenPort() !u16 {
+    var address = try std.net.Address.parseIp("127.0.0.1", 0);
+    var temp = try address.listen(.{ .reuse_address = true });
+    defer temp.deinit();
+    return temp.listen_address.in.getPort();
+}
+
+pub const Server = struct {
+    allocator: std.mem.Allocator,
+    state: ?*HandlerState,
+    ws_server: ?*WsServer,
+    thread: std.Thread,
+    port_value: u16,
 
     pub fn port(self: *const Server) u16 {
-        return self.ctx.?.port;
+        return self.port_value;
+    }
+
+    pub fn stop(self: *Server) void {
+        if (self.ws_server) |srv| srv.stop();
     }
 
     pub fn wait(self: *Server) !ServerResult {
-        const ctx_ptr = self.ctx orelse return error.AlreadyJoined;
-        self.thread.join();
-        self.ctx = null;
-        defer self.allocator.destroy(ctx_ptr);
-        if (ctx_ptr.err) |err| {
-            return err;
+        var result: ServerResult = .{};
+        if (self.state) |state_ptr| {
+            result = state_ptr.result;
         }
-        return ctx_ptr.result;
+        defer self.cleanup();
+        self.stop();
+        self.thread.join();
+        return result;
     }
 
     pub fn ensureStopped(self: *Server) void {
-        if (self.ctx != null) {
-            _ = self.wait() catch {};
+        _ = self.wait() catch {};
+    }
+
+    fn cleanup(self: *Server) void {
+        if (self.ws_server) |srv| {
+            srv.deinit();
+            self.allocator.destroy(srv);
+            self.ws_server = null;
+        }
+        if (self.state) |state_ptr| {
+            state_ptr.deinit();
+            self.allocator.destroy(state_ptr);
+            self.state = null;
         }
     }
 };
 
 pub fn start(allocator: std.mem.Allocator, config: Config) !Server {
-    var address = try std.net.Address.parseIp("127.0.0.1", 0);
-    var server = try address.listen(.{ .reuse_address = true });
-    const port = server.listen_address.in.getPort();
+    var state = try HandlerState.init(allocator, config);
+    errdefer {
+        state.deinit();
+        allocator.destroy(state);
+    }
 
-    const ctx = try allocator.create(ServerContext);
-    ctx.* = .{
-        .server = server,
-        .config = config,
+    const port = try findOpenPort();
+
+    const ws_ptr = try allocator.create(WsServer);
+    errdefer allocator.destroy(ws_ptr);
+    ws_ptr.* = try WsServer.init(allocator, .{
         .port = port,
-    };
+        .address = "127.0.0.1",
+        .worker_count = 1,
+    });
 
-    const thread = try std.Thread.spawn(.{}, serverThread, .{ctx});
+    const thread = try ws_ptr.listenInNewThread(state);
 
-    return .{
-        .ctx = ctx,
-        .thread = thread,
+    return Server{
         .allocator = allocator,
+        .state = state,
+        .ws_server = ws_ptr,
+        .thread = thread,
+        .port_value = port,
     };
-}
-
-fn serverThread(ctx: *ServerContext) void {
-    ctx.result = .{};
-    ctx.err = null;
-    runServer(ctx) catch |err| {
-        ctx.err = err;
-        return;
-    };
-}
-
-fn runServer(ctx: *ServerContext) !void {
-    defer ctx.server.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    var connection = try ctx.server.accept();
-    defer connection.stream.close();
-
-    var buffer = std.ArrayListUnmanaged(u8){};
-    defer buffer.deinit(arena.allocator());
-
-    var tmp: [1024]u8 = undefined;
-    while (true) {
-        const read_len = try connection.stream.read(&tmp);
-        if (read_len == 0) return ServerError.ConnectionClosedEarly;
-        try buffer.appendSlice(arena.allocator(), tmp[0..read_len]);
-        if (std.mem.indexOf(u8, buffer.items, "\r\n\r\n")) |_| break;
-    }
-
-    const request = buffer.items;
-    const headers_end = std.mem.indexOfPos(u8, request, 0, "\r\n\r\n") orelse return ServerError.InvalidHandshakeRequest;
-    const header_bytes = request[0..headers_end];
-
-    var lines = std.mem.splitSequence(u8, header_bytes, "\r\n");
-    const request_line = lines.next() orelse return ServerError.InvalidHandshakeRequest;
-    const expect = ctx.config.expect;
-
-    var saw_versions = false;
-    var saw_features = false;
-    var saw_subprotocol = false;
-    var saw_authenticate_as = false;
-    var saw_server_nonce = false;
-    var sec_key: ?[]const u8 = null;
-    var authenticate_as_bytes: ?[32]u8 = null;
-
-    // Validate request line
-    if (!std.mem.startsWith(u8, request_line, "GET ")) return ServerError.InvalidHandshakeRequest;
-
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
-        const colon_index = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const raw_name = line[0..colon_index];
-        var lowered = try arena.allocator().alloc(u8, raw_name.len);
-        for (raw_name, 0..) |ch, idx| {
-            lowered[idx] = std.ascii.toLower(ch);
-        }
-        const name = std.mem.trim(u8, lowered, &ascii.whitespace);
-        const value = std.mem.trim(u8, line[colon_index + 1 ..], &ascii.whitespace);
-
-        if (std.mem.eql(u8, name, "sec-websocket-key")) {
-            sec_key = value;
-        } else if (std.mem.eql(u8, name, "sec-websocket-protocol")) {
-            saw_subprotocol = std.mem.eql(u8, value, expect.subprotocol);
-        } else if (std.mem.eql(u8, name, "x-mosaic-versions")) {
-            saw_versions = std.mem.eql(u8, value, expect.versions);
-        } else if (std.mem.eql(u8, name, "x-mosaic-features")) {
-            saw_features = std.mem.eql(u8, value, expect.features);
-        } else if (std.mem.eql(u8, name, "x-mosaic-authenticate-as")) {
-            if (expect.authenticate_as) |expected| {
-                saw_authenticate_as = std.mem.eql(u8, value, expected);
-                authenticate_as_bytes = printable.decodeUserPublicKey(value) catch return ServerError.InvalidAuthenticateHeader;
-            }
-        } else if (std.mem.eql(u8, name, "x-mosaic-server-authenticate-nonce")) {
-            if (expect.server_auth_nonce) |nonce| {
-                saw_server_nonce = std.mem.eql(u8, value, nonce);
-            }
-        }
-    }
-
-    ctx.result.saw_versions = saw_versions;
-    ctx.result.saw_features = saw_features;
-    ctx.result.saw_subprotocol = saw_subprotocol;
-    ctx.result.saw_authenticate_as = saw_authenticate_as;
-    ctx.result.saw_server_nonce = saw_server_nonce;
-
-    const websocket_key = sec_key orelse return ServerError.MissingWebSocketKey;
-    var sha = std.crypto.hash.Sha1.init(.{});
-    sha.update(websocket_key);
-    sha.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
-    var digest: [std.crypto.hash.Sha1.digest_length]u8 = undefined;
-    sha.final(&digest);
-
-    var accept_buf: [28]u8 = undefined;
-    const accept_value = std.base64.standard.Encoder.encode(&accept_buf, &digest);
-
-    var response_builder = std.ArrayListUnmanaged(u8){};
-    defer response_builder.deinit(arena.allocator());
-    var response_writer_ctx = ArrayListWriter{ .list = &response_builder, .allocator = arena.allocator() };
-    const response_writer = ListWriter{ .context = &response_writer_ctx };
-
-    const res = ctx.config.response;
-    try std.fmt.format(
-        response_writer,
-        "HTTP/1.1 101 Switching Protocol\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {s}\r\nSec-WebSocket-Protocol: {s}\r\n" ++
-            "X-Mosaic-Version: {s}\r\nX-Mosaic-Features-Accepted: {s}\r\nX-Mosaic-Server-Authentication: {s}\r\n" ++
-            "X-Mosaic-Client-Authenticate-Nonce: {s}\r\n\r\n",
-        .{ accept_value, expect.subprotocol, res.version, res.features_accepted, res.server_authentication, res.client_auth_nonce },
-    );
-
-    try connection.stream.writeAll(response_builder.items);
-
-    const apps_copy = try arena.allocator().alloc(u32, res.hello_ack_applications.len);
-    @memcpy(apps_copy[0..], res.hello_ack_applications);
-    const hello_ack_msg = protocol.Message{ .hello_ack = .{
-        .result = res.hello_ack_result,
-        .max_version = res.hello_ack_max_version,
-        .applications = apps_copy,
-    } };
-    const hello_ack_payload = try protocol.encodeMessage(arena.allocator(), hello_ack_msg);
-    defer arena.allocator().free(hello_ack_payload);
-    try writeServerBinaryFrame(&connection.stream, hello_ack_payload);
-
-    const hello_auth_payload = try readClientBinaryFrame(arena.allocator(), &connection.stream);
-    defer arena.allocator().free(hello_auth_payload);
-
-    ctx.result.hello_auth_seen = hello_auth_payload.len != 0;
-
-    if (res.client_auth_nonce.len != 0 and (expect.authenticate_as != null)) {
-        if (hello_auth_payload.len == 0) return ServerError.MissingHelloAuthPayload;
-        const signature_slice = try parseHelloAuthPayload(hello_auth_payload);
-        var signature: [Ed25519Blake3.signature_length]u8 = undefined;
-        std.mem.copyForwards(u8, signature[0..], signature_slice);
-        const pubkey = authenticate_as_bytes orelse return ServerError.MissingAuthenticateHeader;
-        try Ed25519Blake3.verify(res.client_auth_nonce, signature, pubkey);
-        ctx.result.hello_auth_valid = true;
-    }
-
-    if (res.submission_result_prefix) |prefix| {
-        const submission_msg = protocol.Message{ .submission_result = .{
-            .result = protocol.ResultCode.accepted,
-            .id_prefix = prefix,
-        } };
-        const submission_payload = try protocol.encodeMessage(arena.allocator(), submission_msg);
-        defer arena.allocator().free(submission_payload);
-        try writeServerBinaryFrame(&connection.stream, submission_payload);
-    }
-}
-
-const ArrayListWriter = struct {
-    list: *std.ArrayListUnmanaged(u8),
-    allocator: std.mem.Allocator,
-};
-
-fn listWrite(ctx: *ArrayListWriter, bytes: []const u8) error{OutOfMemory}!usize {
-    try ctx.list.appendSlice(ctx.allocator, bytes);
-    return bytes.len;
-}
-
-const ListWriter = std.io.GenericWriter(*ArrayListWriter, error{OutOfMemory}, listWrite);
-
-fn writeServerBinaryFrame(stream: *std.net.Stream, payload: []const u8) !void {
-    std.debug.assert(payload.len < 126);
-    var header = [_]u8{ 0x82, @intCast(payload.len) };
-    try stream.writeAll(header[0..]);
-    if (payload.len != 0) try stream.writeAll(payload);
-}
-
-fn readExact(stream: *std.net.Stream, buf: []u8) !void {
-    var offset: usize = 0;
-    while (offset < buf.len) {
-        const read_bytes = try stream.read(buf[offset..]);
-        if (read_bytes == 0) return ServerError.ConnectionClosedEarly;
-        offset += read_bytes;
-    }
-}
-
-fn readClientBinaryFrame(allocator: std.mem.Allocator, stream: *std.net.Stream) ![]u8 {
-    var header: [2]u8 = undefined;
-    try readExact(stream, header[0..]);
-
-    if ((header[0] & 0x0F) != 0x2) return ServerError.UnexpectedOpCode;
-    if ((header[1] & 0x80) == 0) return ServerError.UnmaskedFrame;
-
-    var payload_len: usize = header[1] & 0x7F;
-    if (payload_len == 126) {
-        var extended: [2]u8 = undefined;
-        try readExact(stream, extended[0..]);
-        payload_len = (@as(usize, extended[0]) << 8) | extended[1];
-    } else if (payload_len == 127) {
-        return ServerError.FrameTooLarge;
-    }
-
-    var mask: [4]u8 = undefined;
-    try readExact(stream, mask[0..]);
-
-    var payload = try allocator.alloc(u8, payload_len);
-    if (payload_len != 0) {
-        try readExact(stream, payload);
-        var i: usize = 0;
-        while (i < payload_len) : (i += 1) {
-            payload[i] ^= mask[i % 4];
-        }
-    }
-
-    return payload;
-}
-
-fn parseHelloAuthPayload(payload: []const u8) ![]const u8 {
-    if (payload.len != Ed25519Blake3.signature_length) {
-        return ServerError.InvalidHelloAuthPayload;
-    }
-    return payload;
 }

--- a/src/transport/websocket_server.zig
+++ b/src/transport/websocket_server.zig
@@ -1,0 +1,323 @@
+const std = @import("std");
+const mosaic = @import("mosaic");
+const protocol = mosaic.protocol;
+const Ed25519Blake3 = mosaic.Ed25519Blake3;
+const printable = mosaic.printable;
+const ascii = std.ascii;
+
+const ServerError = error{
+    InvalidHandshakeRequest,
+    ConnectionClosedEarly,
+    MissingWebSocketKey,
+    InvalidAuthenticateHeader,
+    MissingAuthenticateHeader,
+    MissingHelloAuthPayload,
+    UnexpectedOpCode,
+    UnmaskedFrame,
+    FrameTooLarge,
+    InvalidHelloAuthPayload,
+};
+
+pub const ExpectHeaders = struct {
+    versions: []const u8,
+    features: []const u8,
+    subprotocol: []const u8 = "mosaic2025",
+    authenticate_as: ?[]const u8 = null,
+    server_auth_nonce: ?[]const u8 = null,
+};
+
+pub const ResponseConfig = struct {
+    version: []const u8,
+    features_accepted: []const u8,
+    server_authentication: []const u8,
+    client_auth_nonce: []const u8,
+    hello_ack_result: protocol.ResultCode = .success,
+    hello_ack_max_version: u8,
+    hello_ack_applications: []const u32,
+    submission_result_prefix: ?[32]u8 = null,
+};
+
+pub const Config = struct {
+    expect: ExpectHeaders,
+    response: ResponseConfig,
+};
+
+pub const ServerResult = struct {
+    saw_versions: bool = false,
+    saw_features: bool = false,
+    saw_subprotocol: bool = false,
+    saw_authenticate_as: bool = false,
+    saw_server_nonce: bool = false,
+    hello_auth_seen: bool = false,
+    hello_auth_valid: bool = false,
+};
+
+const ServerContext = struct {
+    server: std.net.Server,
+    config: Config,
+    result: ServerResult = .{},
+    err: ?anyerror = null,
+    port: u16,
+};
+
+pub const Server = struct {
+    ctx: ?*ServerContext,
+    thread: std.Thread,
+    allocator: std.mem.Allocator,
+
+    pub fn port(self: *const Server) u16 {
+        return self.ctx.?.port;
+    }
+
+    pub fn wait(self: *Server) !ServerResult {
+        const ctx_ptr = self.ctx orelse return error.AlreadyJoined;
+        self.thread.join();
+        self.ctx = null;
+        defer self.allocator.destroy(ctx_ptr);
+        if (ctx_ptr.err) |err| {
+            return err;
+        }
+        return ctx_ptr.result;
+    }
+
+    pub fn ensureStopped(self: *Server) void {
+        if (self.ctx != null) {
+            _ = self.wait() catch {};
+        }
+    }
+};
+
+pub fn start(allocator: std.mem.Allocator, config: Config) !Server {
+    var address = try std.net.Address.parseIp("127.0.0.1", 0);
+    var server = try address.listen(.{ .reuse_address = true });
+    const port = server.listen_address.in.getPort();
+
+    const ctx = try allocator.create(ServerContext);
+    ctx.* = .{
+        .server = server,
+        .config = config,
+        .port = port,
+    };
+
+    const thread = try std.Thread.spawn(.{}, serverThread, .{ctx});
+
+    return .{
+        .ctx = ctx,
+        .thread = thread,
+        .allocator = allocator,
+    };
+}
+
+fn serverThread(ctx: *ServerContext) void {
+    ctx.result = .{};
+    ctx.err = null;
+    runServer(ctx) catch |err| {
+        ctx.err = err;
+        return;
+    };
+}
+
+fn runServer(ctx: *ServerContext) !void {
+    defer ctx.server.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    var connection = try ctx.server.accept();
+    defer connection.stream.close();
+
+    var buffer = std.ArrayListUnmanaged(u8){};
+    defer buffer.deinit(arena.allocator());
+
+    var tmp: [1024]u8 = undefined;
+    while (true) {
+        const read_len = try connection.stream.read(&tmp);
+        if (read_len == 0) return ServerError.ConnectionClosedEarly;
+        try buffer.appendSlice(arena.allocator(), tmp[0..read_len]);
+        if (std.mem.indexOf(u8, buffer.items, "\r\n\r\n")) |_| break;
+    }
+
+    const request = buffer.items;
+    const headers_end = std.mem.indexOfPos(u8, request, 0, "\r\n\r\n") orelse return ServerError.InvalidHandshakeRequest;
+    const header_bytes = request[0..headers_end];
+
+    var lines = std.mem.splitSequence(u8, header_bytes, "\r\n");
+    const request_line = lines.next() orelse return ServerError.InvalidHandshakeRequest;
+    const expect = ctx.config.expect;
+
+    var saw_versions = false;
+    var saw_features = false;
+    var saw_subprotocol = false;
+    var saw_authenticate_as = false;
+    var saw_server_nonce = false;
+    var sec_key: ?[]const u8 = null;
+    var authenticate_as_bytes: ?[32]u8 = null;
+
+    // Validate request line
+    if (!std.mem.startsWith(u8, request_line, "GET ")) return ServerError.InvalidHandshakeRequest;
+
+    while (lines.next()) |line| {
+        if (line.len == 0) break;
+        const colon_index = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const raw_name = line[0..colon_index];
+        var lowered = try arena.allocator().alloc(u8, raw_name.len);
+        for (raw_name, 0..) |ch, idx| {
+            lowered[idx] = std.ascii.toLower(ch);
+        }
+        const name = std.mem.trim(u8, lowered, &ascii.whitespace);
+        const value = std.mem.trim(u8, line[colon_index + 1 ..], &ascii.whitespace);
+
+        if (std.mem.eql(u8, name, "sec-websocket-key")) {
+            sec_key = value;
+        } else if (std.mem.eql(u8, name, "sec-websocket-protocol")) {
+            saw_subprotocol = std.mem.eql(u8, value, expect.subprotocol);
+        } else if (std.mem.eql(u8, name, "x-mosaic-versions")) {
+            saw_versions = std.mem.eql(u8, value, expect.versions);
+        } else if (std.mem.eql(u8, name, "x-mosaic-features")) {
+            saw_features = std.mem.eql(u8, value, expect.features);
+        } else if (std.mem.eql(u8, name, "x-mosaic-authenticate-as")) {
+            if (expect.authenticate_as) |expected| {
+                saw_authenticate_as = std.mem.eql(u8, value, expected);
+                authenticate_as_bytes = printable.decodeUserPublicKey(value) catch return ServerError.InvalidAuthenticateHeader;
+            }
+        } else if (std.mem.eql(u8, name, "x-mosaic-server-authenticate-nonce")) {
+            if (expect.server_auth_nonce) |nonce| {
+                saw_server_nonce = std.mem.eql(u8, value, nonce);
+            }
+        }
+    }
+
+    ctx.result.saw_versions = saw_versions;
+    ctx.result.saw_features = saw_features;
+    ctx.result.saw_subprotocol = saw_subprotocol;
+    ctx.result.saw_authenticate_as = saw_authenticate_as;
+    ctx.result.saw_server_nonce = saw_server_nonce;
+
+    const websocket_key = sec_key orelse return ServerError.MissingWebSocketKey;
+    var sha = std.crypto.hash.Sha1.init(.{});
+    sha.update(websocket_key);
+    sha.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    var digest: [std.crypto.hash.Sha1.digest_length]u8 = undefined;
+    sha.final(&digest);
+
+    var accept_buf: [28]u8 = undefined;
+    const accept_value = std.base64.standard.Encoder.encode(&accept_buf, &digest);
+
+    var response_builder = std.ArrayListUnmanaged(u8){};
+    defer response_builder.deinit(arena.allocator());
+    var response_writer_ctx = ArrayListWriter{ .list = &response_builder, .allocator = arena.allocator() };
+    const response_writer = ListWriter{ .context = &response_writer_ctx };
+
+    const res = ctx.config.response;
+    try std.fmt.format(
+        response_writer,
+        "HTTP/1.1 101 Switching Protocol\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {s}\r\nSec-WebSocket-Protocol: {s}\r\n" ++
+            "X-Mosaic-Version: {s}\r\nX-Mosaic-Features-Accepted: {s}\r\nX-Mosaic-Server-Authentication: {s}\r\n" ++
+            "X-Mosaic-Client-Authenticate-Nonce: {s}\r\n\r\n",
+        .{ accept_value, expect.subprotocol, res.version, res.features_accepted, res.server_authentication, res.client_auth_nonce },
+    );
+
+    try connection.stream.writeAll(response_builder.items);
+
+    const apps_copy = try arena.allocator().alloc(u32, res.hello_ack_applications.len);
+    @memcpy(apps_copy[0..], res.hello_ack_applications);
+    const hello_ack_msg = protocol.Message{ .hello_ack = .{
+        .result = res.hello_ack_result,
+        .max_version = res.hello_ack_max_version,
+        .applications = apps_copy,
+    } };
+    const hello_ack_payload = try protocol.encodeMessage(arena.allocator(), hello_ack_msg);
+    defer arena.allocator().free(hello_ack_payload);
+    try writeServerBinaryFrame(&connection.stream, hello_ack_payload);
+
+    const hello_auth_payload = try readClientBinaryFrame(arena.allocator(), &connection.stream);
+    defer arena.allocator().free(hello_auth_payload);
+
+    ctx.result.hello_auth_seen = hello_auth_payload.len != 0;
+
+    if (res.client_auth_nonce.len != 0 and (expect.authenticate_as != null)) {
+        if (hello_auth_payload.len == 0) return ServerError.MissingHelloAuthPayload;
+        const signature_slice = try parseHelloAuthPayload(hello_auth_payload);
+        var signature: [Ed25519Blake3.signature_length]u8 = undefined;
+        std.mem.copyForwards(u8, signature[0..], signature_slice);
+        const pubkey = authenticate_as_bytes orelse return ServerError.MissingAuthenticateHeader;
+        try Ed25519Blake3.verify(res.client_auth_nonce, signature, pubkey);
+        ctx.result.hello_auth_valid = true;
+    }
+
+    if (res.submission_result_prefix) |prefix| {
+        const submission_msg = protocol.Message{ .submission_result = .{
+            .result = protocol.ResultCode.accepted,
+            .id_prefix = prefix,
+        } };
+        const submission_payload = try protocol.encodeMessage(arena.allocator(), submission_msg);
+        defer arena.allocator().free(submission_payload);
+        try writeServerBinaryFrame(&connection.stream, submission_payload);
+    }
+}
+
+const ArrayListWriter = struct {
+    list: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+};
+
+fn listWrite(ctx: *ArrayListWriter, bytes: []const u8) error{OutOfMemory}!usize {
+    try ctx.list.appendSlice(ctx.allocator, bytes);
+    return bytes.len;
+}
+
+const ListWriter = std.io.GenericWriter(*ArrayListWriter, error{OutOfMemory}, listWrite);
+
+fn writeServerBinaryFrame(stream: *std.net.Stream, payload: []const u8) !void {
+    std.debug.assert(payload.len < 126);
+    var header = [_]u8{ 0x82, @intCast(payload.len) };
+    try stream.writeAll(header[0..]);
+    if (payload.len != 0) try stream.writeAll(payload);
+}
+
+fn readExact(stream: *std.net.Stream, buf: []u8) !void {
+    var offset: usize = 0;
+    while (offset < buf.len) {
+        const read_bytes = try stream.read(buf[offset..]);
+        if (read_bytes == 0) return ServerError.ConnectionClosedEarly;
+        offset += read_bytes;
+    }
+}
+
+fn readClientBinaryFrame(allocator: std.mem.Allocator, stream: *std.net.Stream) ![]u8 {
+    var header: [2]u8 = undefined;
+    try readExact(stream, header[0..]);
+
+    if ((header[0] & 0x0F) != 0x2) return ServerError.UnexpectedOpCode;
+    if ((header[1] & 0x80) == 0) return ServerError.UnmaskedFrame;
+
+    var payload_len: usize = header[1] & 0x7F;
+    if (payload_len == 126) {
+        var extended: [2]u8 = undefined;
+        try readExact(stream, extended[0..]);
+        payload_len = (@as(usize, extended[0]) << 8) | extended[1];
+    } else if (payload_len == 127) {
+        return ServerError.FrameTooLarge;
+    }
+
+    var mask: [4]u8 = undefined;
+    try readExact(stream, mask[0..]);
+
+    var payload = try allocator.alloc(u8, payload_len);
+    if (payload_len != 0) {
+        try readExact(stream, payload);
+        var i: usize = 0;
+        while (i < payload_len) : (i += 1) {
+            payload[i] ^= mask[i % 4];
+        }
+    }
+
+    return payload;
+}
+
+fn parseHelloAuthPayload(payload: []const u8) ![]const u8 {
+    if (payload.len != Ed25519Blake3.signature_length) {
+        return ServerError.InvalidHelloAuthPayload;
+    }
+    return payload;
+}


### PR DESCRIPTION
## Summary
- replace ad-hoc mock with real websocket.server handler that validates Mosaic headers, signs X-Mosaic-Server-Authentication, and verifies HELLO AUTH
- extend integration test to submit and retrieve a real Mosaic record over WebSockets using JSON fixtures
- tighten auth state handling (errdefer dupes, zero keypairs, snapshot server result under lock)

## Testing
- zig build test