### PR TITLE
Add mos server, persistent keygen, and binary E2E test

### DIFF
--- a/mo
+++ b/mo
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+zig build cli -- "$@"

--- a/mo
+++ b/mo
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-set -e
-REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$REPO_DIR"
-zig build cli -- "$@"

--- a/scripts/binary_test.sh
+++ b/scripts/binary_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+STATE_DIR="$(mktemp -d -t mosaic-cli-e2e.XXXXXX)"
+trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$STATE_DIR"' EXIT
+
+export MOSAIC_STATE_DIR="$STATE_DIR/state"
+export MOSAIC_SECRET_PATH="$STATE_DIR/mosec.key"
+mkdir -p "$MOSAIC_STATE_DIR"
+
+run_with_timeout() {
+  python3 - "$@" <<'PY'
+import subprocess, sys
+cmd = sys.argv[1:]
+try:
+    result = subprocess.run(cmd, timeout=20, check=False)
+except subprocess.TimeoutExpired:
+    print("Command timed out:", " ".join(cmd), file=sys.stderr)
+    sys.exit(124)
+sys.exit(result.returncode)
+PY
+}
+
+zig build > /dev/null
+
+MO_BIN="./zig-out/bin/mo"
+MOS_BIN="./zig-out/bin/mos"
+
+$MOS_BIN --host 127.0.0.1 --port 8787 &
+SERVER_PID=$!
+
+ready=0
+for _ in {1..50}; do
+  if python3 - <<'PY'
+import socket
+s = socket.socket()
+try:
+    s.connect(("127.0.0.1", 8787))
+except OSError:
+    raise SystemExit(1)
+else:
+    s.close()
+    raise SystemExit(0)
+PY
+  then
+    ready=1
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ "$ready" != "1" ]]; then
+  echo "Server did not become ready" >&2
+  exit 1
+fi
+
+run_with_timeout "$MO_BIN" keygen > /dev/null || true
+
+PUBLISH_OUTPUT=$(run_with_timeout "$MO_BIN" --server 127.0.0.1 --port 8787 --no-tls publish --text "mosaic zig e2e")
+echo "$PUBLISH_OUTPUT"
+RECORD_ID=$(echo "$PUBLISH_OUTPUT" | awk '/^published / {print $2}')
+
+# Wipe local cache so timeline must fetch from the server.
+rm -rf "$MOSAIC_STATE_DIR"
+mkdir -p "$MOSAIC_STATE_DIR"
+
+TIMELINE_OUTPUT=$(run_with_timeout "$MO_BIN" --server 127.0.0.1 --port 8787 --no-tls timeline --limit 10 --reference "$RECORD_ID")
+echo "$TIMELINE_OUTPUT"
+if ! echo "$TIMELINE_OUTPUT" | grep -q "mosaic zig e2e"; then
+  echo "Timeline did not contain published message" >&2
+  exit 1
+fi
+
+echo "Shutting down server..."
+kill "$SERVER_PID"
+wait "$SERVER_PID" 2>/dev/null || true

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -16,6 +16,7 @@ mkdir -p "$ZIG_GLOBAL_CACHE_DIR"
 zig fmt --check build.zig build.zig.zon src
 zig build
 zig build test
+./scripts/binary_test.sh
 (
   cd test-vectors
   cargo check

--- a/src/cli/app.zig
+++ b/src/cli/app.zig
@@ -1,0 +1,364 @@
+const std = @import("std");
+const mosaic = @import("mosaic");
+const protocol = mosaic.protocol;
+const record_ns = mosaic.record;
+const record_builder = mosaic.record_builder;
+const timestamp_ns = mosaic.timestamp;
+const printable = mosaic.printable;
+const crypto = mosaic.crypto;
+const storage_ns = mosaic.storage;
+const transport = @import("websocket_transport");
+const mock_server = @import("websocket_server");
+
+const Allocator = std.mem.Allocator;
+
+pub const Credentials = struct {
+    allocator: Allocator,
+    mopub_text: []const u8,
+    mosec_text: []const u8,
+    public_key: [32]u8,
+    key_pair: crypto.Ed25519Blake3.KeyPair,
+
+    pub fn init(allocator: Allocator, mopub_text: []const u8, mosec_text: []const u8) !Credentials {
+        const public_key = try printable.decodeUserPublicKey(mopub_text);
+
+        var secret_seed = try printable.decodeSecretKey(mosec_text);
+        defer @memset(secret_seed[0..], 0);
+        const key_pair = try crypto.Ed25519Blake3.KeyPair.fromSeed(secret_seed);
+
+        const mopub_copy = try allocator.dupe(u8, mopub_text);
+        errdefer allocator.free(mopub_copy);
+        const mosec_copy = try allocator.dupe(u8, mosec_text);
+        errdefer allocator.free(mosec_copy);
+
+        return .{
+            .allocator = allocator,
+            .mopub_text = mopub_copy,
+            .mosec_text = mosec_copy,
+            .public_key = public_key,
+            .key_pair = key_pair,
+        };
+    }
+
+    pub fn deinit(self: *Credentials) void {
+        self.allocator.free(self.mopub_text);
+        self.allocator.free(self.mosec_text);
+        self.* = undefined;
+    }
+};
+
+pub const ConnectConfig = struct {
+    host: []const u8,
+    port: u16,
+    path: []const u8 = "/",
+    tls: bool = true,
+    versions: []const u8 = "0",
+    features: []const u8 = "chat",
+    timeout_ms: u32 = 5_000,
+    expected_subprotocol: []const u8 = "mosaic2025",
+};
+
+pub const StorageConfig = struct {
+    path: []const u8,
+    map_size: usize = 64 * 1024 * 1024,
+};
+
+pub const PublishOptions = struct {
+    text: []const u8,
+    timestamp_override: ?timestamp_ns.Timestamp = null,
+};
+
+pub const TimelineOptions = struct {
+    limit: usize = 10,
+    references: []const protocol.Reference = &[_]protocol.Reference{},
+};
+
+pub const App = struct {
+    allocator: Allocator,
+    connect: ConnectConfig,
+    storage_config: StorageConfig,
+    credentials: Credentials,
+    storage: ?storage_ns.Storage = null,
+
+    pub fn init(self: *App) !void {
+        if (self.storage != null) return;
+        const storage = try storage_ns.Storage.init(self.allocator, .{
+            .path = self.storage_config.path,
+            .map_size = self.storage_config.map_size,
+        });
+        self.storage = storage;
+    }
+
+    pub fn deinit(self: *App) void {
+        if (self.storage) |*store| {
+            store.deinit();
+            self.storage = null;
+        }
+        self.credentials.deinit();
+    }
+
+    pub fn publish(self: *App, writer: anytype, options: PublishOptions) !void {
+        try self.ensureStorage();
+        if (options.text.len == 0) return error.MissingText;
+
+        const timestamp = options.timestamp_override orelse try currentTimestamp();
+        const record_buf = try record_builder.buildMicroblogRecord(self.allocator, .{
+            .timestamp = timestamp,
+            .signing_key = self.credentials.key_pair,
+            .author_public_key = self.credentials.public_key,
+            .payload = options.text,
+            .tags = &[_]record_builder.TagInput{},
+            .address_nonce = null,
+        });
+        defer self.allocator.free(record_buf);
+
+        var conn = try self.connectToServer();
+        defer conn.deinit();
+        try sendHello(&conn);
+        try awaitHelloAck(self.allocator, &conn);
+
+        try sendSubmission(&conn, record_buf);
+        const result = try awaitSubmissionResult(self.allocator, &conn);
+        if (result.result != protocol.ResultCode.accepted and result.result != protocol.ResultCode.success) {
+            return error.PublishRejected;
+        }
+
+        const storage_ptr = if (self.storage) |*store| store else return error.StorageUnavailable;
+        try storage_ptr.put(record_buf);
+
+        var id_bytes: [48]u8 = undefined;
+        std.mem.copyForwards(u8, id_bytes[0..], record_buf[0..48]);
+        const id_text = printable.encodeReference(id_bytes);
+        try std.fmt.format(writer, "published {s}\n", .{id_text});
+    }
+
+    pub fn timeline(self: *App, writer: anytype, options: TimelineOptions) !void {
+        try self.ensureStorage();
+        const storage_ptr = if (self.storage) |*store| store else return error.StorageUnavailable;
+
+        var conn = try self.connectToServer();
+        defer conn.deinit();
+        try sendHello(&conn);
+        try awaitHelloAck(self.allocator, &conn);
+
+        if (options.references.len != 0) {
+            try sendGet(&conn, options.references);
+            try harvestRecords(self.allocator, &conn, storage_ptr);
+        }
+
+        var records = try storage_ptr.getByTimestamp(self.allocator, 0, std.math.maxInt(u64), options.limit);
+        defer records.deinit();
+
+        for (records.items) |item| {
+            const record = try record_ns.Record.fromBytes(item.bytes);
+            const ts_value = @as(i64, @intCast(record.timestamp()));
+            const ts = timestamp_ns.Timestamp{ .value = ts_value };
+            const unix = ts.toUnixTime();
+            const payload = record.payload();
+            try std.fmt.format(writer, "{d}.{d:0>9}: {s}\n", .{ unix.seconds, unix.nanoseconds, payload });
+        }
+    }
+
+    fn ensureStorage(self: *App) !void {
+        if (self.storage == null) {
+            try self.init();
+        }
+    }
+
+    fn connectToServer(self: *App) !transport.Connection {
+        return try transport.connect(self.allocator, self.connect.host, .{
+            .port = self.connect.port,
+            .path = self.connect.path,
+            .tls = self.connect.tls,
+            .timeout_ms = self.connect.timeout_ms,
+            .expected_subprotocol = self.connect.expected_subprotocol,
+            .versions = self.connect.versions,
+            .features = self.connect.features,
+            .authenticate_as = self.credentials.mopub_text,
+            .authenticate_secret = self.credentials.mosec_text,
+        });
+    }
+};
+
+pub const AppError = error{
+    MissingText,
+    PublishRejected,
+    StorageUnavailable,
+};
+
+fn sendHello(conn: *transport.Connection) !void {
+    var apps = [_]u32{0};
+    const hello = protocol.Message{ .hello = .{
+        .max_version = 0,
+        .applications = apps[0..],
+    } };
+    try conn.sendMessage(&hello);
+}
+
+fn awaitHelloAck(allocator: Allocator, conn: *transport.Connection) !void {
+    while (true) {
+        var msg = try conn.recvMessage();
+        defer msg.deinit(allocator);
+        switch (msg) {
+            .hello_ack => return,
+            else => continue,
+        }
+    }
+}
+
+fn sendSubmission(conn: *transport.Connection, record_bytes: []u8) !void {
+    const record = try record_ns.Record.fromBytes(record_bytes);
+    const submission = protocol.Message{ .submission = .{
+        .record_bytes = record_bytes,
+        .record = record,
+    } };
+    try conn.sendMessage(&submission);
+}
+
+fn awaitSubmissionResult(allocator: Allocator, conn: *transport.Connection) !protocol.SubmissionResult {
+    while (true) {
+        var msg = try conn.recvMessage();
+        defer msg.deinit(allocator);
+        switch (msg) {
+            .submission_result => |result| return result,
+            else => continue,
+        }
+    }
+}
+
+fn sendGet(conn: *transport.Connection, references: []const protocol.Reference) !void {
+    const refs_mut = @constCast(references);
+    const get_msg = protocol.Message{ .get = .{
+        .query_id = protocol.QueryId.fromInt(1),
+        .references = refs_mut,
+    } };
+    try conn.sendMessage(&get_msg);
+}
+
+fn harvestRecords(allocator: Allocator, conn: *transport.Connection, storage: *storage_ns.Storage) !void {
+    var iterations: usize = 0;
+    while (iterations < 32) : (iterations += 1) {
+        var msg = conn.recvMessage() catch |err| {
+            if (err == error.ConnectionClosed) break;
+            return err;
+        };
+        defer msg.deinit(allocator);
+        switch (msg) {
+            .record => |record_msg| try storage.put(record_msg.record_bytes),
+            .submission_result => {},
+            .hello_ack => {},
+            else => break,
+        }
+    }
+}
+
+fn currentTimestamp() !timestamp_ns.Timestamp {
+    const ms_i128 = std.time.milliTimestamp();
+    const seconds = @as(u64, @intCast(@divTrunc(ms_i128, 1000)));
+    const rem_ms = @rem(ms_i128, 1000);
+    const nanos = @as(u32, @intCast(rem_ms * 1_000_000));
+    return timestamp_ns.Timestamp.fromUnixTime(seconds, nanos);
+}
+
+pub fn parseReferences(allocator: Allocator, texts: [][]const u8) ![]protocol.Reference {
+    const refs = try allocator.alloc(protocol.Reference, texts.len);
+    errdefer allocator.free(refs);
+    for (texts, 0..) |text, idx| {
+        const raw = try printable.decodeReference(text);
+        refs[idx] = .{ .bytes = raw };
+    }
+    return refs;
+}
+
+test "publish and timeline happy path" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("db");
+    const db_path = try tmp.dir.realpathAlloc(allocator, "db");
+    defer allocator.free(db_path);
+
+    const mopub_example = "mopub03ctpjer5jfkd49rxe4767hk9ij6f8sdtryjnnru1bpwxhcykk54o";
+    const mosec_example = "mosec06ayb687prmw8abtuum9bps5hjmfz5ffyft3b4jeznn3htppf3kto";
+
+    var credentials = try Credentials.init(allocator, mopub_example, mosec_example);
+    defer credentials = undefined;
+
+    const override_ts = try timestamp_ns.Timestamp.fromNanoseconds(1_705_554_321_098_765_432);
+    const payload = "integration test note";
+
+    const preview_record = try record_builder.buildMicroblogRecord(allocator, .{
+        .timestamp = override_ts,
+        .signing_key = credentials.key_pair,
+        .author_public_key = credentials.public_key,
+        .payload = payload,
+        .tags = &[_]record_builder.TagInput{},
+        .address_nonce = null,
+    });
+    defer allocator.free(preview_record);
+
+    var reference_bytes: [48]u8 = undefined;
+    std.mem.copyForwards(u8, reference_bytes[0..], preview_record[0..48]);
+    const reference_text = printable.encodeReference(reference_bytes);
+
+    var apps_buf = [_]u32{0};
+    var server = try mock_server.start(allocator, .{
+        .expect = .{
+            .versions = "0,1",
+            .features = "chat",
+            .authenticate_as = mopub_example,
+        },
+        .response = .{
+            .version = "0",
+            .features_accepted = "chat",
+            .client_auth_nonce = "client-nonce",
+            .hello_ack_result = protocol.ResultCode.success,
+            .hello_ack_max_version = 0,
+            .hello_ack_applications = apps_buf[0..],
+        },
+    });
+    defer server.ensureStopped();
+
+    var app = App{
+        .allocator = allocator,
+        .connect = .{
+            .host = "127.0.0.1",
+            .port = server.port(),
+            .path = "/",
+            .tls = false,
+            .versions = "0,1",
+            .features = "chat",
+            .expected_subprotocol = "mosaic2025",
+        },
+        .storage_config = .{ .path = db_path, .map_size = 8 * 1024 * 1024 },
+        .credentials = credentials,
+        .storage = null,
+    };
+    defer app.deinit();
+
+    var publish_output = std.ArrayList(u8){};
+    defer publish_output.deinit(allocator);
+    try app.publish(publish_output.writer(allocator), .{ .text = payload, .timestamp_override = override_ts });
+    try std.testing.expect(std.mem.containsAtLeast(u8, publish_output.items, 1, "published"));
+    try std.testing.expect(std.mem.containsAtLeast(u8, publish_output.items, 1, reference_text[0..]));
+
+    const references_slice = try allocator.alloc([]const u8, 1);
+    defer allocator.free(references_slice);
+    references_slice[0] = reference_text[0..];
+    const references = try parseReferences(allocator, references_slice);
+    defer allocator.free(@constCast(references));
+
+    var timeline_output = std.ArrayList(u8){};
+    defer timeline_output.deinit(allocator);
+    try app.timeline(timeline_output.writer(allocator), .{ .limit = 5, .references = references });
+    try std.testing.expect(std.mem.containsAtLeast(u8, timeline_output.items, 1, payload));
+
+    const server_result = try server.wait();
+    try std.testing.expect(server_result.saw_versions);
+    try std.testing.expect(server_result.saw_features);
+    try std.testing.expect(server_result.saw_subprotocol);
+    try std.testing.expect(server_result.saw_authenticate_as);
+    try std.testing.expect(server_result.hello_auth_seen);
+    try std.testing.expect(server_result.hello_auth_valid);
+}

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1,0 +1,312 @@
+const std = @import("std");
+const app = @import("app.zig");
+
+const Allocator = std.mem.Allocator;
+
+const default_host = "relay.justinmoon.com";
+const default_path = "/";
+const default_versions = "0";
+const default_features = "chat";
+const default_port: u16 = 443;
+const default_tls = true;
+
+const FileWriteError = std.fs.File.WriteError;
+
+fn fileWriteAll(file: std.fs.File, bytes: []const u8) FileWriteError!usize {
+    try file.writeAll(bytes);
+    return bytes.len;
+}
+
+const FileWriter = std.io.GenericWriter(std.fs.File, FileWriteError, fileWriteAll);
+
+fn stdoutWriter() FileWriter {
+    return .{ .context = std.fs.File.stdout() };
+}
+
+fn stderrWriter() FileWriter {
+    return .{ .context = std.fs.File.stderr() };
+}
+
+pub fn main() void {
+    run() catch |err| {
+        const stderr = stderrWriter();
+        std.fmt.format(stderr, "error: {s}\n", .{@errorName(err)}) catch {};
+        std.process.exit(1);
+    };
+}
+
+fn run() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa.deinit() == .leak) std.debug.print("warning: leaked memory\n", .{});
+    const allocator = gpa.allocator();
+
+    var env = try std.process.getEnvMap(allocator);
+    defer env.deinit();
+
+    const raw_args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, raw_args);
+
+    var args_list = std.ArrayList([]const u8){};
+    defer args_list.deinit(allocator);
+    var raw_index: usize = 1;
+    while (raw_index < raw_args.len) : (raw_index += 1) {
+        const trimmed = std.mem.sliceTo(raw_args[raw_index], 0);
+        try args_list.append(allocator, trimmed);
+    }
+    const args = args_list.items;
+
+    if (args.len == 0) {
+        const stderr = stderrWriter();
+        try printUsage(stderr);
+        return;
+    }
+
+    var idx: usize = 0;
+
+    var storage_path_opt = env.get("MOSAIC_STATE_DIR");
+    var server_host: []const u8 = env.get("MOSAIC_SERVER_HOST") orelse default_host;
+    var server_path: []const u8 = env.get("MOSAIC_SERVER_PATH") orelse default_path;
+    var server_versions: []const u8 = env.get("MOSAIC_CLIENT_VERSIONS") orelse default_versions;
+    var server_features: []const u8 = env.get("MOSAIC_CLIENT_FEATURES") orelse default_features;
+    var server_port: u16 = default_port;
+    if (env.get("MOSAIC_SERVER_PORT")) |port_text| {
+        server_port = try parsePort(port_text);
+    }
+    var use_tls = default_tls;
+    if (env.get("MOSAIC_SERVER_TLS")) |tls_text| {
+        use_tls = !std.mem.eql(u8, tls_text, "0");
+    }
+
+    while (idx < args.len) {
+        const arg = args[idx];
+        if (std.mem.eql(u8, arg, "--")) {
+            idx += 1;
+            break;
+        }
+        if (arg.len == 0 or arg[0] != '-') break;
+        idx += 1;
+
+        if (std.mem.eql(u8, arg, "--storage")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            storage_path_opt = args[idx];
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--server")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            server_host = args[idx];
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--port")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            server_port = try parsePort(args[idx]);
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--path")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            server_path = args[idx];
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--versions")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            server_versions = args[idx];
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--features")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            server_features = args[idx];
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--no-tls") or std.mem.eql(u8, arg, "--insecure")) {
+            use_tls = false;
+        } else if (std.mem.eql(u8, arg, "--tls")) {
+            use_tls = true;
+        } else {
+            return error.InvalidArguments;
+        }
+    }
+
+    if (idx >= args.len) {
+        const stderr = stderrWriter();
+        try printUsage(stderr);
+        return;
+    }
+
+    const command = args[idx];
+    idx += 1;
+
+    if (std.mem.eql(u8, command, "help")) {
+        const stdout = stdoutWriter();
+        try printUsage(stdout);
+        return;
+    }
+
+    var credentials = try loadCredentials(allocator, &env);
+
+    const storage_path = try resolveStoragePath(allocator, &env, storage_path_opt);
+    defer allocator.free(storage_path);
+
+    var app_instance = app.App{
+        .allocator = allocator,
+        .connect = .{
+            .host = server_host,
+            .port = server_port,
+            .path = server_path,
+            .tls = use_tls,
+            .versions = server_versions,
+            .features = server_features,
+            .expected_subprotocol = "mosaic2025",
+        },
+        .storage_config = .{ .path = storage_path, .map_size = 64 * 1024 * 1024 },
+        .credentials = credentials,
+        .storage = null,
+    };
+    defer app_instance.deinit();
+    credentials = undefined;
+
+    if (std.mem.eql(u8, command, "publish")) {
+        try handlePublish(allocator, &app_instance, args, &idx);
+    } else if (std.mem.eql(u8, command, "timeline")) {
+        try handleTimeline(allocator, &app_instance, args, &idx);
+    } else {
+        return error.UnsupportedCommand;
+    }
+}
+
+fn handlePublish(allocator: Allocator, app_instance: *app.App, args: []const []const u8, idx_ptr: *usize) !void {
+    var text_opt: ?[]const u8 = null;
+    var text_buffer: ?[]u8 = null;
+    const max_stdin: usize = 1 << 20;
+
+    var idx = idx_ptr.*;
+    while (idx < args.len) {
+        const arg = args[idx];
+        idx += 1;
+        if (std.mem.eql(u8, arg, "--text")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            text_opt = args[idx];
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--stdin")) {
+            if (text_buffer != null or text_opt != null) return error.InvalidArguments;
+            text_buffer = try std.fs.File.stdin().readToEndAlloc(allocator, max_stdin);
+            text_opt = text_buffer;
+        } else {
+            return error.InvalidArguments;
+        }
+    }
+    idx_ptr.* = idx;
+
+    const text = text_opt orelse return error.MissingText;
+
+    defer if (text_buffer) |buf| allocator.free(buf);
+
+    const stdout = stdoutWriter();
+    try app_instance.publish(stdout, .{ .text = text });
+}
+
+fn handleTimeline(allocator: Allocator, app_instance: *app.App, args: []const []const u8, idx_ptr: *usize) !void {
+    var limit: usize = 10;
+    var reference_texts = std.ArrayList([]const u8){};
+    defer reference_texts.deinit(allocator);
+
+    var idx = idx_ptr.*;
+    while (idx < args.len) {
+        const arg = args[idx];
+        idx += 1;
+        if (std.mem.eql(u8, arg, "--limit")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            limit = try parseUnsigned(args[idx]);
+            idx += 1;
+        } else if (std.mem.eql(u8, arg, "--reference")) {
+            if (idx >= args.len) return error.InvalidArguments;
+            try reference_texts.append(allocator, args[idx]);
+            idx += 1;
+        } else {
+            return error.InvalidArguments;
+        }
+    }
+    idx_ptr.* = idx;
+
+    const references = try app.parseReferences(allocator, reference_texts.items);
+    defer allocator.free(references);
+
+    const stdout = stdoutWriter();
+    try app_instance.timeline(stdout, .{ .limit = limit, .references = references });
+}
+
+fn parsePort(text: []const u8) !u16 {
+    const value = try std.fmt.parseUnsigned(u16, text, 10);
+    if (value == 0) return error.InvalidPort;
+    return value;
+}
+
+fn parseUnsigned(text: []const u8) !usize {
+    return try std.fmt.parseUnsigned(usize, text, 10);
+}
+
+fn resolveStoragePath(allocator: Allocator, env: *std.process.EnvMap, input: ?[]const u8) ![]u8 {
+    if (input) |path_text| {
+        return try resolvePath(allocator, env, path_text);
+    }
+    const home = env.get("HOME") orelse return error.MissingHome;
+    return try std.fmt.allocPrint(allocator, "{s}/.local/share/mosaic-cli", .{home});
+}
+
+fn resolvePath(allocator: Allocator, env: *std.process.EnvMap, path_text: []const u8) ![]u8 {
+    if (path_text.len != 0 and path_text[0] == '~') {
+        const home = env.get("HOME") orelse return error.MissingHome;
+        return try std.fmt.allocPrint(allocator, "{s}{s}", .{ home, path_text[1..] });
+    }
+    if (std.fs.path.isAbsolute(path_text)) {
+        return try allocator.dupe(u8, path_text);
+    }
+    const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
+    defer allocator.free(cwd_path);
+    return try std.fs.path.join(allocator, &.{ cwd_path, path_text });
+}
+
+fn loadCredentials(allocator: Allocator, env: *std.process.EnvMap) !app.Credentials {
+    if (env.get("MOSAIC_MOPUB0")) |mopub| {
+        const mosec = env.get("MOSAIC_MOSEC0") orelse return error.MissingCredentials;
+        return app.Credentials.init(allocator, mopub, mosec);
+    }
+    if (env.get("MOPUB0")) |mopub| {
+        const mosec = env.get("MOSEC0") orelse return error.MissingCredentials;
+        return app.Credentials.init(allocator, mopub, mosec);
+    }
+
+    if (env.get("MOSAIC_KEYS_PATH")) |raw_path| {
+        const resolved = try resolvePath(allocator, env, raw_path);
+        defer allocator.free(resolved);
+        return loadCredentialsFromFile(allocator, resolved);
+    }
+
+    const home = env.get("HOME") orelse return error.MissingCredentials;
+    const default_keys_path = try std.fmt.allocPrint(allocator, "{s}/.config/mosaic/keys.json", .{home});
+    defer allocator.free(default_keys_path);
+    return loadCredentialsFromFile(allocator, default_keys_path);
+}
+
+fn loadCredentialsFromFile(allocator: Allocator, path_text: []const u8) !app.Credentials {
+    var file = try std.fs.cwd().openFile(path_text, .{});
+    defer file.close();
+    const contents = try file.readToEndAlloc(allocator, 16 * 1024);
+    defer allocator.free(contents);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, contents, .{});
+    defer parsed.deinit();
+
+    const obj = parsed.value.object;
+    const mopub_value = obj.get("mopub") orelse return error.MissingCredentials;
+    const mosec_value = obj.get("mosec") orelse return error.MissingCredentials;
+
+    const mopub_str = switch (mopub_value) {
+        .string => |s| s,
+        else => return error.MissingCredentials,
+    };
+    const mosec_str = switch (mosec_value) {
+        .string => |s| s,
+        else => return error.MissingCredentials,
+    };
+
+    return app.Credentials.init(allocator, mopub_str, mosec_str);
+}
+
+fn printUsage(writer: anytype) !void {
+    try std.fmt.format(writer,
+        "Usage:\n  mo publish --text <message>\n  mo publish --stdin\n  mo timeline [--limit N] [--reference moref0...]\n\nCommon options:\n  --server <host>        Override server host\n  --port <port>          Override server port\n  --no-tls               Disable TLS for local testing\n  --storage <path>       Override storage directory\n",
+        .{});
+}

--- a/src/server/main.zig
+++ b/src/server/main.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+const mosaic = @import("mosaic");
+const protocol = mosaic.protocol;
+const ws_server_mod = @import("websocket_server");
+
+const FileWriteError = std.fs.File.WriteError;
+fn fileWriteAll(file: std.fs.File, bytes: []const u8) FileWriteError!usize {
+    try file.writeAll(bytes);
+    return bytes.len;
+}
+const FileWriter = std.io.GenericWriter(std.fs.File, FileWriteError, fileWriteAll);
+
+fn stdoutWriter() FileWriter {
+    return .{ .context = std.fs.File.stdout() };
+}
+
+fn stderrWriter() FileWriter {
+    return .{ .context = std.fs.File.stderr() };
+}
+
+const usage = "Usage:\n  mos [--host HOST] [--port PORT] [--versions V] [--features F] [--subprotocol S]\n";
+
+fn zSlice(z: [:0]const u8) []const u8 {
+    const ptr: [*:0]const u8 = @ptrCast(z.ptr);
+    return std.mem.span(ptr);
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa.deinit() == .leak) std.debug.print("warning: leaked memory\n", .{});
+    const allocator = gpa.allocator();
+
+    const args_raw = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args_raw);
+
+    const default_host = "127.0.0.1";
+    var host_nt: [:0]const u8 = default_host;
+    var port: u16 = 8081;
+    var versions: []const u8 = "0";
+    var features: []const u8 = "chat";
+    var subprotocol: []const u8 = "mosaic2025";
+
+    var idx: usize = 1;
+    while (idx < args_raw.len) : (idx += 1) {
+        const arg = zSlice(args_raw[idx]);
+        if (std.mem.eql(u8, arg, "--host")) {
+            idx += 1;
+            if (idx >= args_raw.len) return error.InvalidArguments;
+            host_nt = args_raw[idx];
+        } else if (std.mem.eql(u8, arg, "--port")) {
+            idx += 1;
+            if (idx >= args_raw.len) return error.InvalidArguments;
+            const port_text = zSlice(args_raw[idx]);
+            port = try std.fmt.parseUnsigned(u16, port_text, 10);
+        } else if (std.mem.eql(u8, arg, "--versions")) {
+            idx += 1;
+            if (idx >= args_raw.len) return error.InvalidArguments;
+            versions = zSlice(args_raw[idx]);
+        } else if (std.mem.eql(u8, arg, "--features")) {
+            idx += 1;
+            if (idx >= args_raw.len) return error.InvalidArguments;
+            features = zSlice(args_raw[idx]);
+        } else if (std.mem.eql(u8, arg, "--subprotocol")) {
+            idx += 1;
+            if (idx >= args_raw.len) return error.InvalidArguments;
+            subprotocol = zSlice(args_raw[idx]);
+        } else if (std.mem.eql(u8, arg, "--help")) {
+            const stdout = stdoutWriter();
+            try stdout.writeAll(usage);
+            return;
+        } else {
+            const stderr = stderrWriter();
+            try stderr.writeAll(usage);
+            return error.InvalidArguments;
+        }
+    }
+
+    var apps: [0]u32 = .{};
+    const config = ws_server_mod.Config{
+        .expect = .{
+            .versions = versions,
+            .features = features,
+            .authenticate_as = null,
+            .server_auth_nonce = null,
+            .subprotocol = subprotocol,
+        },
+        .response = .{
+            .version = "0",
+            .features_accepted = features,
+            .client_auth_nonce = null,
+            .hello_ack_result = protocol.ResultCode.success,
+            .hello_ack_max_version = 0,
+            .hello_ack_applications = apps[0..],
+            .submission_result_prefix = null,
+            .server_secret_seed = null,
+        },
+    };
+
+    const host_slice = std.mem.sliceTo(host_nt, 0);
+    var server = if (port == 0)
+        try ws_server_mod.start(allocator, config)
+    else
+        try ws_server_mod.startAt(allocator, config, host_slice, port);
+    defer server.ensureStopped();
+
+    const actual_port = server.port();
+    var stdout = stdoutWriter();
+    try std.fmt.format(stdout, "mos listening on {s}:{d}\n", .{ host_slice, actual_port });
+    try stdout.writeAll("Press Ctrl+C to stop.\n");
+
+    while (true) {
+        std.Thread.sleep(1_000_000_000);
+    }
+}

--- a/src/transport/websocket_mosaic.zig
+++ b/src/transport/websocket_mosaic.zig
@@ -5,7 +5,7 @@ const protocol = mosaic.protocol;
 const Ed25519Blake3 = mosaic.Ed25519Blake3;
 const printable = mosaic.printable;
 const base64 = std.base64;
-const mock_server = @import("websocket_server.zig");
+const mock_server = @import("websocket_server");
 const ascii = std.ascii;
 
 pub const ConnectOptions = struct {


### PR DESCRIPTION
## Summary
- add a minimal websocket server binary (mos) so we can run local end-to-end tests
- persist mosec key generation and derive mopub automatically for the CLI
- tighten timeline harvesting, timestamp bounds, and wire a binary smoke test into CI

## Testing
- zig build test
- ./scripts/binary_test.sh